### PR TITLE
move snapshot dependency to parent pom.

### DIFF
--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -33,15 +33,9 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>mqtt-client</artifactId>
-            <version>0.4.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>Eclipse Paho Repo</id>
-            <url>https://repo.eclipse.org/content/repositories/paho-snapshots/</url>
-        </repository>
-    </repositories>
+
 
 </project>

--- a/modules/integration/tests-platform/tests-clustering/pom.xml
+++ b/modules/integration/tests-platform/tests-clustering/pom.xml
@@ -221,17 +221,14 @@
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.event.stub</artifactId>
-            <version>${carbon.platform.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.andes.stub</artifactId>
-            <version>4.2.1</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.mb</groupId>
             <artifactId>org.wso2.mb.platform.common.utils</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.automation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -189,12 +189,30 @@
                 <scope>test</scope>
             </dependency>
 
-            <!-- Snapshot eclipse mqtt client -->
+            <!-- Snapshot dependency eclipse mqtt client -->
 
             <dependency>
                 <groupId>org.eclipse.paho</groupId>
                 <artifactId>mqtt-client</artifactId>
                 <version>${mqttclient.version}</version>
+            </dependency>
+
+            <!-- Clustering test dependecies -->
+
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.event.stub</artifactId>
+                <version>${carbon.platform.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.andes.stub</artifactId>
+                <version>${andesstub.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.mb</groupId>
+                <artifactId>org.wso2.mb.platform.common.utils</artifactId>
+                <version>${product.mb.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -302,6 +320,7 @@
         <carbon.platform.version>4.3.0-SNAPSHOT</carbon.platform.version>
         <product.mb.version>3.0.0-SNAPSHOT</product.mb.version>
         <test.framework.version>4.3.1</test.framework.version>
+        <andesstub.version>4.2.1</andesstub.version>
 	    <!-- Rampart -->
         <rampart.version>1.6.1-wso2v10</rampart.version>
         <rampart.mar.version>1.6.1-wso2v10</rampart.mar.version>
@@ -310,7 +329,7 @@
         <!--Apache Derby-->
         <version.wso2.derby>10.3.2.1wso2v1</version.wso2.derby>
         <emma.version>2.1.5320</emma.version>
-        <!-- mqtt client snapshot-->
+        <!--Mqtt client snapshot-->
         <mqttclient.version>0.4.1-SNAPSHOT</mqttclient.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,9 +188,23 @@
                 <version>${carbon.platform.version}</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- Snapshot eclipse mqtt client -->
+
+            <dependency>
+                <groupId>org.eclipse.paho</groupId>
+                <artifactId>mqtt-client</artifactId>
+                <version>${mqttclient.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
+    <repositories>
+        <repository>
+            <id>Eclipse Paho Repo</id>
+            <url>https://repo.eclipse.org/content/repositories/paho-snapshots/</url>
+        </repository>
+    </repositories>
 
     <scm>
         <connection>scm:git:https://github.com/wso2/product-mb.git</connection>
@@ -296,6 +310,8 @@
         <!--Apache Derby-->
         <version.wso2.derby>10.3.2.1wso2v1</version.wso2.derby>
         <emma.version>2.1.5320</emma.version>
+        <!-- mqtt client snapshot-->
+        <mqttclient.version>0.4.1-SNAPSHOT</mqttclient.version>
     </properties>
 
 </project>


### PR DESCRIPTION
since there are no stable dependancies available for mqtt client with
version 0.4.1. this snapshot dependency has to keep in parent pom.