### PR TITLE
Eclipse paho mqtt-client version downgraded to 0.4.0

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -39,7 +39,6 @@
         <dependency>
             <groupId>org.apache.rampart</groupId>
             <artifactId>rampart</artifactId>
-            <version>${rampart.mar.version}</version>
             <type>mar</type>
         </dependency>
         <dependency>

--- a/modules/features/service/org.wso2.stratos.mb.dashboard.ui.feature/pom.xml
+++ b/modules/features/service/org.wso2.stratos.mb.dashboard.ui.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.mb</groupId>
         <artifactId>wso2stratos-mb-features</artifactId>
-        <version>${product.mb.version}</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/service/org.wso2.stratos.mb.deployment.feature/pom.xml
+++ b/modules/features/service/org.wso2.stratos.mb.deployment.feature/pom.xml
@@ -22,7 +22,7 @@
      <parent>
         <groupId>org.wso2.mb</groupId>
         <artifactId>wso2stratos-mb-features</artifactId>
-        <version>${product.mb.version}</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/service/org.wso2.stratos.mb.login.ui.feature/pom.xml
+++ b/modules/features/service/org.wso2.stratos.mb.login.ui.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.mb</groupId>
         <artifactId>wso2stratos-mb-features</artifactId>
-        <version>${product.mb.version}</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/service/org.wso2.stratos.mb.styles.feature/pom.xml
+++ b/modules/features/service/org.wso2.stratos.mb.styles.feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.mb</groupId>
         <artifactId>wso2stratos-mb-features</artifactId>
-        <version>${product.mb.version}</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/features/service/pom.xml
+++ b/modules/features/service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.mb</groupId>
     	<artifactId>mb-features-parent</artifactId>
-        <version>${product.mb.version}</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -33,16 +33,6 @@
     <packaging>pom</packaging>
     <name>WSO2 Stratos Message Broker - Features Aggregator Module</name>
     <description>Features specific to the WSO2 Message Broker</description>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.wso2.mb</groupId>
-                <artifactId>org.wso2.stratos.mb.styles</artifactId>
-                <version>${product.mb.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <modules>
         <module>org.wso2.stratos.mb.styles.feature</module>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -44,25 +44,6 @@
         <module>tests-platform</module>
     </modules>
 
-    <dependencies>
-        <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.andes.wso2</groupId>
-            <artifactId>andes-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.event.stub</artifactId>
-        </dependency>
-    </dependencies>
-
     <build>
         <plugins>
             <plugin>

--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -38,13 +38,9 @@
             <groupId>org.wso2.carbon.messaging</groupId>
             <artifactId>org.wso2.carbon.andes.stub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.commons</groupId>
+            <artifactId>org.wso2.carbon.event.stub</artifactId>
+        </dependency>
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>Eclipse Paho Repo</id>
-            <url>https://repo.eclipse.org/content/repositories/paho-snapshots/</url>
-        </repository>
-    </repositories>
-
 </project>

--- a/modules/org.wso2.stratos.mb.dashboard.ui/pom.xml
+++ b/modules/org.wso2.stratos.mb.dashboard.ui/pom.xml
@@ -19,7 +19,7 @@
     <parent>
     	<groupId>org.wso2.mb</groupId>
     	<artifactId>mb-parent</artifactId>
-    	<version>${product.mb.version}</version>
+    	<version>2.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/org.wso2.stratos.mb.login.ui/pom.xml
+++ b/modules/org.wso2.stratos.mb.login.ui/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.mb</groupId>
         <artifactId>mb-parent</artifactId>
-        <version>${product.mb.version}</version>
+        <version>2.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/samples/product/mqtt_IoTSample/pom.xml
+++ b/modules/samples/product/mqtt_IoTSample/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.wso2.mb</groupId>
     <artifactId>org.wso2.mb.samples.mqtt.iot</artifactId>
-    <version>${product.mb.version}</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -34,17 +34,14 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6.0.wso2v1</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.13</version>
         </dependency>
     </dependencies>
 

--- a/modules/samples/product/mqtt_chat_client/pom.xml
+++ b/modules/samples/product/mqtt_chat_client/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.wso2.mb</groupId>
     <artifactId>org.wso2.mb.sample.mqtt.chat</artifactId>
-    <version>${product.mb.version}</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/modules/samples/product/simple_mqtt_client/pom.xml
+++ b/modules/samples/product/simple_mqtt_client/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.wso2.mb</groupId>
     <artifactId>org.wso2.mb.samples.mqtt.simple</artifactId>
-    <version>${product.mb.version}</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -34,12 +34,10 @@
         <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
-            <version>1.1</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.13</version>
         </dependency>
     </dependencies>
 
@@ -63,13 +61,6 @@
             </plugin>
         </plugins>
     </build>
-
-    <repositories>
-        <repository>
-            <id>Eclipse Paho Repo</id>
-            <url>https://repo.eclipse.org/content/repositories/paho-snapshots/</url>
-        </repository>
-    </repositories>
 
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,22 @@
                 <artifactId>org.wso2.mb.styles</artifactId>
                 <version>${product.mb.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.mb</groupId>
+                <artifactId>org.wso2.stratos.mb.styles</artifactId>
+                <version>${product.mb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-lang.wso2</groupId>
+                <artifactId>commons-lang</artifactId>
+                <version>${commons.lang.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.rampart</groupId>
+                <artifactId>rampart</artifactId>
+                <version>${rampart.mar.version}</version>
+                <type>mar</type>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <profiles>
@@ -389,8 +405,9 @@
 
         <carbon.ui.menu.stratos.version>2.0.0</carbon.ui.menu.stratos.version>
         <commons.logging.version>1.1</commons.logging.version>
+        <commons.lang.version>2.6.0.wso2v1</commons.lang.version>
         <testng.version>6.8.5</testng.version>
-        <eclipse.paho.mqtt.client.version>0.4.1-SNAPSHOT</eclipse.paho.mqtt.client.version>
+        <eclipse.paho.mqtt.client.version>0.4.0</eclipse.paho.mqtt.client.version>
 
     </properties>
 
@@ -409,4 +426,11 @@
         </plugins>
     </build>
 
+    <!--eclipse paho mqtt-client-->
+    <repositories>
+        <repository>
+            <id>Eclipse Paho Repo</id>
+            <url>https://repo.eclipse.org/content/repositories/paho-snapshots/</url>
+        </repository>
+    </repositories>
 </project>


### PR DESCRIPTION
Eclipse paho mqtt-client version downgraded to 0.4.0. Removed unnecessary dependencies. Added versions for sample modules.