### PR TITLE
Fixed missing 'TenantDeleteClusterMessage' class and missing 'PropertiesFileInitialContextFactory' class

### DIFF
--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.wso2.andes.wso2</groupId>
             <artifactId>andes-client</artifactId>
+            <version>${andes.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs.wso2</groupId>

--- a/modules/distribution/pom.xml
+++ b/modules/distribution/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>org.wso2.andes.wso2</groupId>
             <artifactId>andes-client</artifactId>
-            <version>${andes.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs.wso2</groupId>

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -42,32 +42,28 @@
         <module>tests-platform</module>
     </modules>
 
-    <!--<dependencies>-->
-        <!--<dependency>-->
-            <!--<groupId>org.testng</groupId>-->
-            <!--<artifactId>testng</artifactId>-->
-            <!--<version>6.8.5</version>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>commons-logging</groupId>-->
-            <!--<artifactId>commons-logging</artifactId>-->
-            <!--<version>1.1.1</version>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>org.wso2.andes.wso2</groupId>-->
-            <!--<artifactId>andes-client</artifactId>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>org.wso2.carbon.commons</groupId>-->
-            <!--<artifactId>org.wso2.carbon.event.stub</artifactId>-->
-        <!--</dependency>-->
-        <!--<dependency>-->
-            <!--<groupId>org.wso2.carbon.messaging</groupId>-->
-            <!--<artifactId>org.wso2.carbon.andes.stub</artifactId>-->
-        <!--</dependency>-->
-
-
-    <!--</dependencies>-->
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.andes.wso2</groupId>
+            <artifactId>andes-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.commons</groupId>
+            <artifactId>org.wso2.carbon.event.stub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.messaging</groupId>
+            <artifactId>org.wso2.carbon.andes.stub</artifactId>
+        </dependency>
+    </dependencies>
 
     <!--<build>-->
         <!--<plugins>-->

--- a/modules/integration/pom.xml
+++ b/modules/integration/pom.xml
@@ -42,21 +42,48 @@
         <module>tests-platform</module>
     </modules>
 
-    <!--build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-clean-plugin</artifactId>
-                <version>2.4.1</version>
-                <executions>
-                    <execution>
-                        <id>auto-clean</id>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>clean</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build-->
+    <!--<dependencies>-->
+        <!--<dependency>-->
+            <!--<groupId>org.testng</groupId>-->
+            <!--<artifactId>testng</artifactId>-->
+            <!--<version>6.8.5</version>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>commons-logging</groupId>-->
+            <!--<artifactId>commons-logging</artifactId>-->
+            <!--<version>1.1.1</version>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>org.wso2.andes.wso2</groupId>-->
+            <!--<artifactId>andes-client</artifactId>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>org.wso2.carbon.commons</groupId>-->
+            <!--<artifactId>org.wso2.carbon.event.stub</artifactId>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>org.wso2.carbon.messaging</groupId>-->
+            <!--<artifactId>org.wso2.carbon.andes.stub</artifactId>-->
+        <!--</dependency>-->
+
+
+    <!--</dependencies>-->
+
+    <!--<build>-->
+        <!--<plugins>-->
+            <!--<plugin>-->
+                <!--<artifactId>maven-clean-plugin</artifactId>-->
+                <!--<version>2.4.1</version>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>auto-clean</id>-->
+                        <!--<phase>initialize</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>clean</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
+        <!--</plugins>-->
+    <!--</build>-->
 </project>

--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -40,5 +40,9 @@
             <groupId>org.wso2.carbon.commons</groupId>
             <artifactId>org.wso2.carbon.event.stub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.andes.wso2</groupId>
+            <artifactId>andes-client</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/integration/tests-common/admin-clients/pom.xml
+++ b/modules/integration/tests-common/admin-clients/pom.xml
@@ -32,17 +32,5 @@
             <groupId>org.eclipse.paho</groupId>
             <artifactId>mqtt-client</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.messaging</groupId>
-            <artifactId>org.wso2.carbon.andes.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.event.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.andes.wso2</groupId>
-            <artifactId>andes-client</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/modules/integration/tests-platform/tests-clustering/pom.xml
+++ b/modules/integration/tests-platform/tests-clustering/pom.xml
@@ -217,14 +217,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.wso2.carbon.commons</groupId>
-            <artifactId>org.wso2.carbon.event.stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wso2.carbon.messaging</groupId>
-            <artifactId>org.wso2.carbon.andes.stub</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.mb</groupId>
             <artifactId>org.wso2.mb.platform.common.utils</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
         <carbon.identity.version>4.3.2</carbon.identity.version>
         <carbon.registry.version>4.3.0</carbon.registry.version>
         <carbon.messaging.version>2.5.0</carbon.messaging.version>
-        <carbon.multitenancy.version>4.3.3</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.3.4</carbon.multitenancy.version>
         <carbon.storagemgt.version>4.3.1</carbon.storagemgt.version>
 
         <carbon.kernel.version>4.3.0</carbon.kernel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -387,7 +387,7 @@
         <carbon.commons.version>4.3.4</carbon.commons.version>
         <carbon.identity.version>4.3.2</carbon.identity.version>
         <carbon.registry.version>4.3.0</carbon.registry.version>
-        <carbon.messaging.version>2.5.0</carbon.messaging.version>
+        <carbon.messaging.version>3.0.0-SNAPSHOT</carbon.messaging.version>
         <carbon.multitenancy.version>4.3.4</carbon.multitenancy.version>
         <carbon.storagemgt.version>4.3.1</carbon.storagemgt.version>
 


### PR DESCRIPTION
Fixed the following errors that occurs when running test cases.
1. Caused by: java.lang.ClassNotFoundException: org.wso2.carbon.tenant.mgt.message.TenantDeleteClusterMessage
2. Caused by: java.lang.ClassNotFoundException: org.wso2.andes.jndi.PropertiesFileInitialContextFactory