### PR TITLE
Adding ;DB_CLOSE_DELAY=-1 to in-mem mode in master-datasources.xml

### DIFF
--- a/modules/distribution/src/main/conf/master-datasources.xml
+++ b/modules/distribution/src/main/conf/master-datasources.xml
@@ -94,7 +94,7 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url>jdbc:h2:mem:msg_store</url>
+                    <url>jdbc:h2:mem:msg_store;DB_CLOSE_DELAY=-1</url>
                     <driverClassName>org.h2.Driver</driverClassName>
                 </configuration>
             </definition>

--- a/modules/integration/tests-integration/tests-amqp/src/test/resources/testing-H2-mem.xml
+++ b/modules/integration/tests-integration/tests-amqp/src/test/resources/testing-H2-mem.xml
@@ -52,7 +52,6 @@
             <!--H2 In-memory does not store data during a server restart-->
             <!--<class  name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicServerRestartTestCase"/>-->
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionWithSameClientIdTestCase"/>
             <!--<class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicTestCase"/>-->
             <class name="org.wso2.mb.integration.tests.amqp.functional.HierarchicalTopicsTestCase"/>
             <!--<class name="org.wso2.mb.integration.tests.amqp.functional.MixedDurableTopicTestCase"/>-->
@@ -64,6 +63,11 @@
             <class name="org.wso2.mb.integration.tests.amqp.functional.TemporaryTopicSubscriptionVerificationTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TopicMessageSequentialAndDuplicateTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TopicTestCase"/>
+
+            <!-- Following is commented out since it requires config replacement and hence cannot be address
+                 in both embedded and in-mem modes since that will require two different configs for two
+                 db modes, which is not supported in this test model -->
+            <!--<class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionWithSameClientIdTestCase"/>-->
 
             <!-- load test cases-->
 


### PR DESCRIPTION
Removing DurableTopicSubscriptionWithSameClientIdTestCase from H2 in-mem tests and adding ;DB_CLOSE_DELAY=-1 to in-mem mode in master-datasources.xml.