### PR TITLE
MB-1021 issue fixed

### DIFF
--- a/modules/distribution/src/main/conf/hazelcast.properties
+++ b/modules/distribution/src/main/conf/hazelcast.properties
@@ -1,1 +1,2 @@
 hazelcast.max.no.heartbeat.seconds=600
+hazelcast.shutdownhook.enabled=false


### PR DESCRIPTION
 - hazelcast.shutdownhook.enabled=false property added to hazelcast.property file to fix  Hazelcast instance is not active exception when MB server gracefully shutting down.