### PR TITLE
Memory mode needs to be enabled to run in-memory tests

### DIFF
--- a/modules/distribution/src/main/conf/master-datasources.xml
+++ b/modules/distribution/src/main/conf/master-datasources.xml
@@ -88,7 +88,7 @@
 
         <!-- WSO2 MB in memory store (Experimental feature)
         NOTE: In memory mode only works on single node mode -->
-<!--
+
         <datasource>
             <name>WSO2_MB_IN_MEMORY_STORE_DB</name>
             <jndiConfig>
@@ -101,7 +101,7 @@
                 </configuration>
             </definition>
         </datasource>
--->
+
 
         <!-- external Cassandra data source. please enable either one of datasource (CQL or Hector) based on your preference -->
         <!-- CQL datasource -->


### PR DESCRIPTION
In-memory mode needs to be enabled to run in memory mode tests

Until we find a proper way to activate this, within the framework (need to change broker.xml + master-datasources.xml) when we restart server for in-memory tests, uncommenting.