### PR TITLE
Adding amqp/mqtt ssl passwords to cipher tool configs

### DIFF
--- a/modules/distribution/src/main/conf/cipher-text.properties
+++ b/modules/distribution/src/main/conf/cipher-text.properties
@@ -10,3 +10,9 @@ Server.Service.Connector.keystorePass=[wso2carbon]
 
 # MB-Specific
 Datasources.WSO2_MB_STORE_DB.Configuration.Password=[wso2carbon]
+
+#AMQP / MQTT JKS store passwords
+transports.amqp.sslConnection.keyStore.password=[wso2carbon]
+transports.amqp.sslConnection.trustStore.password=[wso2carbon]
+transports.mqtt.sslConnection.keyStore.password=[wso2carbon]
+transports.mqtt.sslConnection.trustStore.password=[wso2carbon]

--- a/modules/distribution/src/main/conf/cipher-tool.properties
+++ b/modules/distribution/src/main/conf/cipher-tool.properties
@@ -13,3 +13,9 @@ Server.Service.Connector.keystorePass=repository/conf/tomcat/catalina-server.xml
 
 # MB-Specific
 Datasources.WSO2_MB_STORE_DB.Configuration.Password=repository/conf/datasources/master-datasources.xml//datasources-configuration/datasources/datasource[name='WSO2_MB_STORE_DB']/definition/configuration/password,false
+
+#AMQP / MQTT JKS store passwords
+transports.amqp.sslConnection.keyStore.password=repository/conf/broker.xml//broker/transports/amqp/sslConnection/keyStore/password,true
+transports.amqp.sslConnection.trustStore.password=repository/conf/broker.xml//broker/transports/amqp/sslConnection/trustStore/password,true
+transports.mqtt.sslConnection.keyStore.password=repository/conf/broker.xml//broker/transports/mqtt/sslConnection/keyStore/password,true
+transports.mqtt.sslConnection.trustStore.password=repository/conf/broker.xml//broker/transports/mqtt/sslConnection/trustStore/password,true


### PR DESCRIPTION
This is with reference to jiras :

https://wso2.org/jira/browse/MB-924 
https://wso2.org/jira/browse/MB-1160

Default ciphertool entries have been added for AMQP / MQTT SSL keystore passwords.

This is dependent on : 

https://github.com/wso2/andes/pull/219
https://github.com/wso2/carbon-business-messaging/pull/100