### PR TITLE
Fixed exception thrown when clearing empty DLC in build tests

### DIFF
--- a/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/ui/pages/main/DLCContentPage.java
+++ b/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/ui/pages/main/DLCContentPage.java
@@ -63,7 +63,9 @@ public class DLCContentPage {
         // Get all the TR elements from the table
         List<WebElement> allDlcRows = dlcTable.findElements(By.tagName("tr"));
 
-            if(allDlcRows.size() > 0) {
+            //The table header row always exists
+            //Therefore, if messages are there in the dlc, the number of rows will be > 1
+            if(allDlcRows.size() > 1) {
                 log.info("delete all dlc messages");
                 driver.findElement(By.xpath(UIElementMapper.getInstance()
                                                     .getElement("mb.dlc.browse.table.choose.all.box.xpath")))


### PR DESCRIPTION
Tests fail with a no such element method thrown when trying to clear the DLC when the dlc is empty.

This was corrected by checking whether the dlc message table row count is greater than 1