### PR TITLE
Removed autocommit false from CarbonDB

### DIFF
--- a/modules/distribution/src/main/conf/master-datasources.xml
+++ b/modules/distribution/src/main/conf/master-datasources.xml
@@ -62,7 +62,6 @@
                     <testOnBorrow>true</testOnBorrow>
                     <validationQuery>SELECT 1</validationQuery>
                     <validationInterval>30000</validationInterval>
-                    <defaultAutoCommit>false</defaultAutoCommit>
                 </configuration>
             </definition>
         </datasource>


### PR DESCRIPTION
Removed autoCommit=false from CarbonDB configurations in master-datasources.xml 