### PR TITLE
Fixed durable topic messages not being restored from DLC issue

### DIFF
--- a/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/ui/pages/main/DLCContentPage.java
+++ b/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/ui/pages/main/DLCContentPage.java
@@ -63,9 +63,9 @@ public class DLCContentPage {
         // Get all the TR elements from the table
         List<WebElement> allDlcRows = dlcTable.findElements(By.tagName("tr"));
 
-            //The table header row always exists
-            //Therefore, if messages are there in the dlc, the number of rows will be > 1
-            if(allDlcRows.size() > 1) {
+            //A row represents a message in DLC
+            //Therefore comparing the row count with zero is used to see if the message list is empty
+            if(allDlcRows.size() > 0) {
                 log.info("delete all dlc messages");
                 driver.findElement(By.xpath(UIElementMapper.getInstance()
                                                     .getElement("mb.dlc.browse.table.choose.all.box.xpath")))

--- a/modules/integration/tests-common/integration-tests-utils/src/main/resources/mapper.properties
+++ b/modules/integration/tests-common/integration-tests-utils/src/main/resources/mapper.properties
@@ -45,6 +45,7 @@ mb.add.queue.page.permission.table=//*[@id="permissionsTable"]/tbody
 mb.add.queue.page.onqueueadd.okbutton.xpath=/html/body/div[3]/div[2]/button
 mb.add.queue.page.onqueueadd.msgdialog.id=dialog
 mb.queue.list.table.body.xpath=//*[@id="workArea"]/table[2]/tbody
+mb.queue.browse.content.table=//*[@id="workArea"]/table[2]/tbody
 home.logged.user.dev=logged-user
 mb.popup.dialog.id=dialog
 
@@ -124,7 +125,7 @@ mb.dlc.queue.content=//*[@id="middle"]/h2
 
 mb.dlc.browse.table.choose.box.xpath=//*[@id="workArea"]/table[3]/tbody/tr[1]/td[1]/input
 mb.dlc.browse.table.choose.all.box.xpath=//*[@id="workArea"]/table[3]/thead/tr/th[1]/input
-mb.dlc.browse.content.table=//*[@id="workArea"]/table[2]/tbody
+mb.dlc.browse.content.table=//*[@id="workArea"]/table[3]/tbody
 mb.dlc.first.message.id=//*[@id="workArea"]/table[3]/tbody/tr[1]/td[3]
 mb.dlc.browse.function.confirm=/html/body/div[3]/div[2]/button[1]
 mb.dlc.browse.function.success=/html/body/div[3]/div[2]/button

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/dlc/DLCQueueTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/dlc/DLCQueueTestCase.java
@@ -204,7 +204,7 @@ public class DLCQueueTestCase extends MBIntegrationUiBaseTest {
 
         QueuesBrowsePage queuesBrowsePage = homePage.getQueuesBrowsePage();
         queuesBrowsePage.browseQueue(DLC_TEST_QUEUE);
-        if (isElementPresent(UIElementMapper.getInstance().getElement("mb.dlc.browse.content.table"))) {
+        if (isElementPresent(UIElementMapper.getInstance().getElement("mb.queue.browse.content.table"))) {
             restoredMessageID = driver.findElement(By.xpath(UIElementMapper.getInstance().
                                                                 getElement("mb.dlc.restored.message.id"))).getText();
 

--- a/modules/integration/tests-ui-integration/src/test/resources/testng-server-mgt.xml
+++ b/modules/integration/tests-ui-integration/src/test/resources/testng-server-mgt.xml
@@ -32,7 +32,7 @@
             <class name="org.wso2.carbon.mb.ui.test.login.LoginTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.queues.BrowseQueueContentTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.dlc.DLCQueueTestCase"/>
-            <!--<class name="org.wso2.carbon.mb.ui.test.dlc.DLCDurableTopicTestCase"/>-->
+            <class name="org.wso2.carbon.mb.ui.test.dlc.DLCDurableTopicTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.configure.UserStoreManagementTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.queues.QueueDeleteTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.queues.QueueCreationTestCase"/>


### PR DESCRIPTION
Enabled the DLCDurableTopicTestCase which was disabled due to https://wso2.org/jira/browse/MB-1184.

Also, corrected an error in deleteAllDLCMessages() method in DLCContentPage which was caused by the fact that messages were counted from a wrong table.

Please merge https://github.com/wso2/andes/pull/281 along with this or else the test will fail.