### PR TITLE
[MB-1197] Automated database assertion and message count configuration

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/AndesJMSConsumer.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/AndesJMSConsumer.java
@@ -459,8 +459,6 @@ public class AndesJMSConsumer extends AndesJMSBase
                     .getMaximumMessagesToReceived()) {
                 // Stopping the consumer
                 stopClient();
-                // Waiting till consumer is closed so that no messages will be read.
-                AndesClientUtils.sleepForInterval(1000L);
                 return true;
             }
 

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/utils/AndesClientOutputParser.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/utils/AndesClientOutputParser.java
@@ -84,7 +84,8 @@ public class AndesClientOutputParser {
                 String line = br.readLine();
                 while (line != null) {
                     String tempSendMessageString = line.substring(AndesClientConstants.PUBLISH_MESSAGE_FORMAT.indexOf("Sending Message:") + "Sending Message:".length());
-                    long messageIdentifier = Long.parseLong(tempSendMessageString.substring(0, tempSendMessageString.indexOf(" ")));
+                    long messageIdentifier = Long.valueOf(tempSendMessageString.substring(0, tempSendMessageString
+                            .indexOf(" ")).replace(",",""));
                     this.addMessage(messageIdentifier);
                     line = br.readLine();
                 }

--- a/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/DataAccessUtil.java
+++ b/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/DataAccessUtil.java
@@ -1,0 +1,180 @@
+/*
+*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.mb.platform.common.utils;
+
+import org.wso2.mb.platform.common.utils.exceptions.DataAccessUtilException;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * This class is used for testing database records directly.
+ */
+public class DataAccessUtil {
+
+    /**
+     * Get database connection
+     * @return database connection
+     * @throws DataAccessUtilException
+     */
+    private Connection getConnection() throws DataAccessUtilException {
+        return RDBMSConnectionManager.getConnection();
+    }
+
+    /**
+     * Get current number of messages in database for a given queue name.
+     * @param queueName queue name
+     * @return number of messages in database
+     * @throws DataAccessUtilException
+     */
+    public long getMessageCountForQueue(String queueName) throws DataAccessUtilException{
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+        ResultSet resultSet = null;
+        long count = 0;
+        try {
+            connection = getConnection();
+            long queueId = getQueueId(queueName);
+            preparedStatement = connection.prepareStatement(RDBMSConstants.PS_GET_MESSAGE_COUNT_FOR_QUEUE);
+            preparedStatement.setLong(1, queueId);
+            resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                count = resultSet.getLong(RDBMSConstants.MSG_COUNT);
+            }
+        } catch (Exception e) {
+            throw new DataAccessUtilException("Failed to get message count for queue: " + queueName, e);
+        }
+        finally {
+            close(resultSet, "getMessageCountForQueue");
+            close(preparedStatement, "getMessageCountForQueue");
+            close(connection, "getMessageCountForQueue");
+        }
+        return count;
+    }
+
+    /**
+     * Get queue id for a given queue.
+     * @param queueName queue name
+     * @return queue id
+     * @throws DataAccessUtilException
+     */
+    public long getQueueId(String queueName) throws DataAccessUtilException {
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+        ResultSet resultSet = null;
+        long count = 0;
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(RDBMSConstants.PS_GET_QUEUE_ID);
+            preparedStatement.setString(1, queueName);
+            resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                count = resultSet.getLong(RDBMSConstants.QUEUE_ID);
+            }
+        } catch (Exception e) {
+            throw new DataAccessUtilException("Failed to get queue id for queue: " + queueName, e);
+        } finally {
+            close(resultSet, "getQueueId");
+            close(preparedStatement, "getQueueId");
+            close(connection, "getQueueId");
+        }
+        return count;
+    }
+
+    /**
+     * Get current number of slots for a given queue which are in assigned state.
+     * @param queueName queue name
+     * @return number of slots
+     * @throws DataAccessUtilException
+     */
+    public long getAssignedSlotCountForQueue(String queueName) throws DataAccessUtilException{
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+        ResultSet resultSet = null;
+        long count = 0;
+        try {
+            connection = getConnection();
+            preparedStatement = connection.prepareStatement(RDBMSConstants.PS_GET_ASSIGNED_SLOTS_FOR_QUEUE);
+            preparedStatement.setString(1, queueName);
+            resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                count = resultSet.getLong(RDBMSConstants.SLOT_COUNT);
+            }
+        } catch (Exception e) {
+            throw new DataAccessUtilException("Failed to get slot count for queue: " + queueName, e);
+        }
+        finally {
+            close(resultSet, "getAssignedSlotCountForQueue");
+            close(preparedStatement, "getAssignedSlotCountForQueue");
+            close(connection, "getAssignedSlotCountForQueue");
+        }
+        return count;
+    }
+
+    /**
+     * closes the result set resources
+     *
+     * @param resultSet ResultSet
+     * @param task      task that was done by the closed result set.
+     */
+    protected void close(ResultSet resultSet, String task) throws DataAccessUtilException{
+        if (resultSet != null) {
+            try {
+                resultSet.close();
+            } catch (SQLException e) {
+                throw new DataAccessUtilException("Failed to close result set", e);
+            }
+        }
+    }
+
+    /**
+     * close the prepared statement resource
+     *
+     * @param preparedStatement PreparedStatement
+     * @param task              task that was done by the closed prepared statement.
+     */
+    protected void close(PreparedStatement preparedStatement, String task) throws DataAccessUtilException{
+        if (preparedStatement != null) {
+            try {
+                preparedStatement.close();
+            } catch (SQLException e) {
+                throw new DataAccessUtilException("Failed to close prepared statement", e);
+            }
+        }
+    }
+
+    /**
+     * Closes the provided connection. on failure log the error;
+     *
+     * @param connection Connection
+     * @param task       task that was done before closing
+     */
+    protected void close(Connection connection, String task) throws DataAccessUtilException{
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                throw new DataAccessUtilException("Failed to close database connection", e);
+            }
+        }
+    }
+
+}

--- a/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/RDBMSConnectionManager.java
+++ b/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/RDBMSConnectionManager.java
@@ -1,0 +1,57 @@
+/*
+*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.mb.platform.common.utils;
+
+import org.wso2.mb.platform.common.utils.exceptions.DataAccessUtilException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+/**
+ * This class is used for creating RDBMS Connection
+ */
+public class RDBMSConnectionManager {
+
+    // Set JDBC URL
+    private static String url = "jdbc:mysql://localhost/WSO2_MB";
+    private static String driverName = "com.mysql.jdbc.Driver";
+    // Set database username
+    private static String username = "";
+    // Set database password
+    private static String password = "";
+    private static Connection conn;
+
+    /**
+     * Get database connection.
+     * @return database connection
+     * @throws DataAccessUtilException
+     */
+    public static Connection getConnection() throws DataAccessUtilException {
+        try {
+            Class.forName(driverName);
+            conn = DriverManager.getConnection(url, username, password);
+            return conn;
+        } catch (SQLException e) {
+            throw new DataAccessUtilException("SQL error occurred while getting message count for queue", e);
+        } catch (ClassNotFoundException e1) {
+            throw new DataAccessUtilException("JDBC driver not found", e1);
+        }
+    }
+}

--- a/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/RDBMSConstants.java
+++ b/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/RDBMSConstants.java
@@ -1,0 +1,72 @@
+/*
+*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.mb.platform.common.utils;
+
+/**
+ * This class contains prepared statements for DataAccessUtil
+ */
+public class RDBMSConstants {
+
+    // Message Store tables
+    protected static final String METADATA_TABLE = "MB_METADATA";
+    protected static final String QUEUES_TABLE = "MB_QUEUE_MAPPING";
+
+    // Message Store table columns
+    protected static final String MESSAGE_ID = "MESSAGE_ID";
+    protected static final String QUEUE_ID = "QUEUE_ID";
+    protected static final String QUEUE_NAME = "QUEUE_NAME";
+
+    // Slot related tables
+    protected static final String SLOT_TABLE = "MB_SLOT";
+
+    //Slot table columns
+    protected static final String SLOT_ID = "SLOT_ID";
+    protected static final String STORAGE_QUEUE_NAME = "STORAGE_QUEUE_NAME";
+    protected static final String SLOT_STATE = "SLOT_STATE";
+
+    //Return variables
+    protected static final String MSG_COUNT = "MSG_COUNT";
+    protected static final String SLOT_COUNT = "SLOT_COUNT";
+
+    /**
+     * Prepared statement for getting queue id
+     */
+    protected static final String PS_GET_QUEUE_ID =
+            "SELECT " + QUEUE_ID
+                + " FROM " + QUEUES_TABLE
+                + " WHERE " + QUEUE_NAME + "=?";
+
+    /**
+     * Prepared statement for getting message count for a given queue
+     */
+    protected static final String PS_GET_MESSAGE_COUNT_FOR_QUEUE =
+            "SELECT COUNT(" + MESSAGE_ID + ") AS " + MSG_COUNT
+                + " FROM " + METADATA_TABLE
+                + " WHERE " + QUEUE_ID + "=?";
+
+    /**
+     * Prepared statement for getting slots for a given queue which are in assigned state
+     */
+    protected static final String PS_GET_ASSIGNED_SLOTS_FOR_QUEUE =
+            " SELECT COUNT(" + SLOT_ID + ") AS " + SLOT_COUNT
+                + " FROM " + SLOT_TABLE
+                + " WHERE " + STORAGE_QUEUE_NAME + "=?"
+                + " AND " + SLOT_STATE + "=2";
+
+}

--- a/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/exceptions/DataAccessUtilException.java
+++ b/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/exceptions/DataAccessUtilException.java
@@ -1,0 +1,74 @@
+/*
+*  Copyright (c) 2015, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.mb.platform.common.utils.exceptions;
+
+/**
+ * Exception class for Data access utility class.
+ */
+public class DataAccessUtilException extends Exception {
+
+    /**
+     * Error message for exception
+     */
+    public String errorMessage;
+
+    /**
+     * Creates Data Access Util exception.
+     */
+    public DataAccessUtilException() {
+    }
+
+    /**
+     * Creates Data Access Util  exception with error message.
+     *
+     * @param message Error message
+     */
+    public DataAccessUtilException(String message) {
+        super(message);
+        errorMessage = message;
+    }
+
+    /**
+     * Creates Data Access Util  exception with error message and throwable.
+     *
+     * @param message Error message
+     * @param cause   The throwable
+     */
+    public DataAccessUtilException(String message, Throwable cause) {
+        super(message, cause);
+        errorMessage = message;
+    }
+
+    /**
+     * Creates Data Access Util  exception with throwable.
+     *
+     * @param cause The throwable
+     */
+    public DataAccessUtilException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getMessage() {
+        return errorMessage;
+    }
+}

--- a/modules/integration/tests-platform/tests-clustering/pom.xml
+++ b/modules/integration/tests-platform/tests-clustering/pom.xml
@@ -257,6 +257,10 @@
             <groupId>org.jacoco</groupId>
             <artifactId>org.jacoco.agent</artifactId>
         </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentMessageTypesQueueTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentMessageTypesQueueTestCase.java
@@ -22,6 +22,7 @@ import com.google.common.net.HostAndPort;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.wso2.carbon.andes.stub.AndesAdminServiceBrokerManagerAdminException;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
@@ -37,7 +38,9 @@ import org.wso2.mb.integration.common.clients.exceptions.AndesClientConfiguratio
 import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 import org.wso2.mb.integration.common.clients.operations.utils.ExchangeType;
 import org.wso2.mb.integration.common.clients.operations.utils.JMSMessageType;
+import org.wso2.mb.platform.common.utils.DataAccessUtil;
 import org.wso2.mb.platform.common.utils.MBPlatformBaseTest;
+import org.wso2.mb.platform.common.utils.exceptions.DataAccessUtilException;
 import org.xml.sax.SAXException;
 
 import javax.jms.JMSException;
@@ -54,6 +57,8 @@ import java.rmi.RemoteException;
  * stream) which can be sent to a topic.
  */
 public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
+
+    private DataAccessUtil dataAccessUtil = new DataAccessUtil();
 
     /**
      * Prepare environment for tests.
@@ -86,12 +91,12 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "single publisher single subscriber byte messages",
             enabled = true)
-    public void testByteMessageSingleSubSinglePub()
-            throws XPathExpressionException, AndesClientConfigurationException, NamingException,
-                   JMSException,
-                   IOException, AndesClientException {
+    @Parameters({"messageCount"})
+    public void testByteMessageSingleSubSinglePub(long messageCount)
+            throws XPathExpressionException, AndesClientConfigurationException, NamingException, JMSException,
+                   IOException, AndesClientException, DataAccessUtilException {
 
-        this.runMessageTypeTestCase(JMSMessageType.BYTE, 1, "byteMessageQueue1");
+        this.runMessageTypeTestCase(JMSMessageType.BYTE, 1, "byteMessageQueue1", messageCount);
     }
 
     /**
@@ -107,12 +112,12 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "multiple publisher multiple subscriber byte " +
                                             "messages", enabled = true)
-    public void testByteMessageMultipleSubMultiplePub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
+    @Parameters({"messageCount"})
+    public void testByteMessageMultipleSubMultiplePub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
 
-        this.runMessageTypeTestCase(JMSMessageType.BYTE, 10, "byteMessageQueue2");
+        this.runMessageTypeTestCase(JMSMessageType.BYTE, 10, "byteMessageQueue2", messageCount);
     }
 
     /**
@@ -128,11 +133,11 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "single publisher single subscriber map messages",
             enabled = true)
-    public void testMapMessageSingleSubSinglePub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.MAP, 1, "mapMessageQueue1");
+    @Parameters({"messageCount"})
+    public void testMapMessageSingleSubSinglePub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
+        this.runMessageTypeTestCase(JMSMessageType.MAP, 1, "mapMessageQueue1", messageCount);
     }
 
     /**
@@ -148,11 +153,11 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "multiple publisher multiple subscriber map " +
                                             "messages", enabled = true)
-    public void testMapMessageMultiplePubMultipleSub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.MAP, 10, "mapMessageQueue2");
+    @Parameters({"messageCount"})
+    public void testMapMessageMultiplePubMultipleSub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
+        this.runMessageTypeTestCase(JMSMessageType.MAP, 10, "mapMessageQueue2", messageCount);
     }
 
     /**
@@ -168,11 +173,11 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "single publisher single subscriber object messages",
             enabled = true)
-    public void testObjectMessageSingleSubSinglePub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.OBJECT, 1, "objectMessageQueue1");
+    @Parameters({"messageCount"})
+    public void testObjectMessageSingleSubSinglePub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
+        this.runMessageTypeTestCase(JMSMessageType.OBJECT, 1, "objectMessageQueue1", messageCount);
     }
 
     /**
@@ -187,11 +192,11 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "multiple publisher multiple subscriber object " +
                                             "messages", enabled = true)
-    public void testObjectMessageMultiplePubMultipleSub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.OBJECT, 10, "objectMessageQueue2");
+    @Parameters({"messageCount"})
+    public void testObjectMessageMultiplePubMultipleSub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
+        this.runMessageTypeTestCase(JMSMessageType.OBJECT, 10, "objectMessageQueue2", messageCount);
     }
 
     /**
@@ -207,11 +212,11 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "single publisher single subscriber stream messages",
             enabled = true)
-    public void testStreamMessageSingleSubSinglePub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.STREAM, 1, "streamMessageQueue1");
+    @Parameters({"messageCount"})
+    public void testStreamMessageSingleSubSinglePub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
+        this.runMessageTypeTestCase(JMSMessageType.STREAM, 1, "streamMessageQueue1", messageCount);
     }
 
     /**
@@ -227,11 +232,11 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "multiple publisher multiple subscriber stream " +
                                             "messages", enabled = true)
-    public void testStreamMessageMultiplePubMultipleSub()
-            throws IOException, JMSException, AndesClientConfigurationException,
-                   XPathExpressionException,
-                   NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.STREAM, 10, "streamMessageQueue2");
+    @Parameters({"messageCount"})
+    public void testStreamMessageMultiplePubMultipleSub(long messageCount)
+            throws IOException, JMSException, AndesClientConfigurationException, XPathExpressionException,
+                   NamingException, AndesClientException, DataAccessUtilException {
+        this.runMessageTypeTestCase(JMSMessageType.STREAM, 10, "streamMessageQueue2", messageCount);
     }
 
     /**
@@ -287,13 +292,15 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
      * @throws AndesClientException
      */
     private void runMessageTypeTestCase(JMSMessageType messageType, int numberOfPublishers,
-                                        String destinationName)
-            throws XPathExpressionException, AndesClientConfigurationException, NamingException,
-                   JMSException,
-                   IOException, AndesClientException {
+                                        String destinationName, long messageCount)
+            throws XPathExpressionException, AndesClientConfigurationException, NamingException, JMSException,
+                   IOException, AndesClientException, DataAccessUtilException {
+
+
 
         // Number of messages send
-        long sendCount = 2000L;
+        long sendCount = messageCount;
+        long printDivider = 10L;
 
         HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
 
@@ -301,14 +308,15 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
         AndesJMSConsumerClientConfiguration consumerConfig =
                 new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
                                     brokerAddress.getPort(), ExchangeType.QUEUE, destinationName);
-        consumerConfig.setPrintsPerMessageCount(sendCount / 10L);
+        consumerConfig.setMaximumMessagesToReceived(sendCount * numberOfPublishers);
+        consumerConfig.setPrintsPerMessageCount(sendCount / printDivider);
 
         // Creating publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
                 new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
                                      brokerAddress.getPort(), ExchangeType.QUEUE, destinationName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
-        publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
+        publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
         publisherConfig.setJMSMessageType(messageType);
 
         // Creating clients
@@ -322,9 +330,14 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
                 .waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
 
         // Evaluating
-        Assert.assertEquals(publisherClient
-                            .getSentMessageCount(), sendCount * numberOfPublishers, "Message sending failed.");
-        Assert.assertEquals(consumerClient
-                            .getReceivedMessageCount(), sendCount * numberOfPublishers, "Message receiving failed.");
+        Assert.assertEquals(publisherClient.getSentMessageCount(), sendCount * numberOfPublishers,
+                            "Message sending failed.");
+        Assert.assertEquals(consumerClient.getReceivedMessageCount(), sendCount * numberOfPublishers,
+                            "Message receiving failed.");
+
+        // Evaluate messages left in database
+        Assert.assertEquals(dataAccessUtil.getMessageCountForQueue(destinationName), 0, "Messages left in database");
+        // Evaluate slots left in database
+        Assert.assertEquals(dataAccessUtil.getAssignedSlotCountForQueue(destinationName), 0, "Slots left in database");
     }
 }

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/durable/topic/DurableTopicSubscriptionTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/durable/topic/DurableTopicSubscriptionTestCase.java
@@ -20,6 +20,7 @@ package org.wso2.mb.platform.tests.clustering.durable.topic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
@@ -54,8 +55,6 @@ public class DurableTopicSubscriptionTestCase extends MBPlatformBaseTest {
     private int portInNode1;
     private int portInNode2;
     private TopicAdminClient topicAdminClient;
-    private static final long SEND_COUNT = 500L;
-    private static final long EXPECTED_COUNT = SEND_COUNT;
 
     /**
      * Prepare environment for tests.
@@ -96,9 +95,14 @@ public class DurableTopicSubscriptionTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "Reconnect to topic with same sub ID after " +
                                             "disconnecting", enabled = true)
-    public void subscribeDisconnectAndSubscribeAgainTest()
+    @Parameters({"messageCount"})
+    public void subscribeDisconnectAndSubscribeAgainTest(long messageCount)
             throws JMSException, NamingException, AndesClientConfigurationException, IOException,
             AndesClientException {
+
+        long sendCount = messageCount;
+        long expectedCount = messageCount;
+
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
                 new AndesJMSConsumerClientConfiguration(hostNode1, portInNode1, ExchangeType.TOPIC, "durableTopicPublishing1");
@@ -106,8 +110,8 @@ public class DurableTopicSubscriptionTestCase extends MBPlatformBaseTest {
 
         AndesJMSPublisherClientConfiguration publisherConfig =
                 new AndesJMSPublisherClientConfiguration(hostNode2, portInNode2, ExchangeType.TOPIC, "durableTopicPublishing1");
-        publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
-        publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
+        publisherConfig.setNumberOfMessagesToSend(sendCount);
+        publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
 
         // Creating clients
         AndesClient consumerClient = new AndesClient(consumerConfig, true);
@@ -119,8 +123,8 @@ public class DurableTopicSubscriptionTestCase extends MBPlatformBaseTest {
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
 
         // Evaluating
-        Assert.assertEquals(publisherClient.getSentMessageCount(), SEND_COUNT, "Message sending failed.");
-        Assert.assertEquals(consumerClient.getReceivedMessageCount(), EXPECTED_COUNT, "Message receiving failed.");
+        Assert.assertEquals(publisherClient.getSentMessageCount(), sendCount, "Message sending failed.");
+        Assert.assertEquals(consumerClient.getReceivedMessageCount(), expectedCount, "Message receiving failed.");
     }
 
     /**

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/DifferentMessageTypesTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/DifferentMessageTypesTopicTestCase.java
@@ -22,6 +22,7 @@ package org.wso2.mb.platform.tests.clustering.topic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
@@ -93,12 +94,13 @@ public class DifferentMessageTypesTopicTestCase extends MBPlatformBaseTest {
      * @throws AndesClientException
      */
     @Test(groups = "wso2.mb", description = "Single publisher single subscriber byte messages", enabled = true)
-    public void testByteMessageSingleSubSinglePubTopic()
+    @Parameters({"messageCount"})
+    public void testByteMessageSingleSubSinglePubTopic(long messageCount)
             throws IOException, JMSException, AndesClientConfigurationException,
                    XPathExpressionException,
                    NamingException, AndesClientException {
 
-        this.runMessageTypeTestCase(JMSMessageType.BYTE, "byteTopic1");
+        this.runMessageTypeTestCase(JMSMessageType.BYTE, "byteTopic1", messageCount);
     }
 
     /**
@@ -114,11 +116,12 @@ public class DifferentMessageTypesTopicTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "Single publisher single subscriber map messages",
             enabled = true)
-    public void testMapMessageSingleSubSinglePubTopic()
+    @Parameters({"messageCount"})
+    public void testMapMessageSingleSubSinglePubTopic(long messageCount)
             throws IOException, JMSException, AndesClientConfigurationException,
                    XPathExpressionException,
                    NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.MAP, "mapTopic1");
+        this.runMessageTypeTestCase(JMSMessageType.MAP, "mapTopic1", messageCount);
     }
 
     /**
@@ -134,11 +137,12 @@ public class DifferentMessageTypesTopicTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "Single publisher single subscriber object messages",
             enabled = true)
-    public void testObjectMessageSingleSubSinglePubTopic()
+    @Parameters({"messageCount"})
+    public void testObjectMessageSingleSubSinglePubTopic(long messageCount)
             throws IOException, JMSException, AndesClientConfigurationException,
                    XPathExpressionException,
                    NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.OBJECT, "objectTopic1");
+        this.runMessageTypeTestCase(JMSMessageType.OBJECT, "objectTopic1", messageCount);
     }
 
     /**
@@ -154,11 +158,12 @@ public class DifferentMessageTypesTopicTestCase extends MBPlatformBaseTest {
      */
     @Test(groups = "wso2.mb", description = "Single publisher single subscriber stream messages",
             enabled = true)
-    public void testStreamMessageSingleSubSinglePubTopic()
+    @Parameters({"messageCount"})
+    public void testStreamMessageSingleSubSinglePubTopic(long messageCount)
             throws IOException, JMSException, AndesClientConfigurationException,
                    XPathExpressionException,
                    NamingException, AndesClientException {
-        this.runMessageTypeTestCase(JMSMessageType.STREAM, "streamTopic1");
+        this.runMessageTypeTestCase(JMSMessageType.STREAM, "streamTopic1", messageCount);
     }
 
     /**
@@ -190,15 +195,15 @@ public class DifferentMessageTypesTopicTestCase extends MBPlatformBaseTest {
      * @throws IOException
      * @throws AndesClientException
      */
-    private void runMessageTypeTestCase(JMSMessageType messageType, String destinationName)
+    private void runMessageTypeTestCase(JMSMessageType messageType, String destinationName, long messageCount)
             throws XPathExpressionException, AndesClientConfigurationException, NamingException,
                    JMSException,
                    IOException, AndesClientException {
 
         // Number of expected messages
-        long expectedCount = 2000L;
+        long expectedCount = messageCount;
         // Number of messages send
-        long sendCount = 2000L;
+        long sendCount = messageCount;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(automationContext.getInstance().getHosts().get("default"),

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/MultipleTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/MultipleTopicTestCase.java
@@ -21,6 +21,7 @@ package org.wso2.mb.platform.tests.clustering.topic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
@@ -52,8 +53,6 @@ import java.rmi.RemoteException;
  */
 public class MultipleTopicTestCase extends MBPlatformBaseTest {
 
-    private static final long EXPECTED_COUNT = 2000L;
-    private static final long SEND_COUNT = 2000L;
     private AutomationContext automationContext;
     private TopicAdminClient topicAdminClient;
 
@@ -91,21 +90,28 @@ public class MultipleTopicTestCase extends MBPlatformBaseTest {
      * @throws AndesClientException
      */
     @Test(groups = "wso2.mb", description = "Same node publisher subscriber test case")
-    public void testMultipleTopicSingleNode()
+    @Parameters({"messageCount"})
+    public void testMultipleTopicSingleNode(long messageCount)
             throws JMSException, AndesClientConfigurationException, XPathExpressionException,
                    NamingException,
                    IOException, AndesClientException {
+
+        // Number of expected messages
+        long expectedCount = messageCount;
+        // Number of messages send
+        long sendCount = messageCount;
+
         // Creating receiver clients
-        AndesClient receivingClient1 = getAndesReceiverClient("topic1", EXPECTED_COUNT);
-        AndesClient receivingClient2 = getAndesReceiverClient("topic2", EXPECTED_COUNT);
-        AndesClient receivingClient3 = getAndesReceiverClient("topic3", EXPECTED_COUNT);
-        AndesClient receivingClient4 = getAndesReceiverClient("topic4", EXPECTED_COUNT);
-        AndesClient receivingClient5 = getAndesReceiverClient("topic5", EXPECTED_COUNT);
-        AndesClient receivingClient6 = getAndesReceiverClient("topic6", EXPECTED_COUNT);
-        AndesClient receivingClient7 = getAndesReceiverClient("topic7", EXPECTED_COUNT);
-        AndesClient receivingClient8 = getAndesReceiverClient("topic8", EXPECTED_COUNT);
-        AndesClient receivingClient9 = getAndesReceiverClient("topic9", EXPECTED_COUNT);
-        AndesClient receivingClient10 = getAndesReceiverClient("topic10", EXPECTED_COUNT);
+        AndesClient receivingClient1 = getAndesReceiverClient("topic1", expectedCount);
+        AndesClient receivingClient2 = getAndesReceiverClient("topic2", expectedCount);
+        AndesClient receivingClient3 = getAndesReceiverClient("topic3", expectedCount);
+        AndesClient receivingClient4 = getAndesReceiverClient("topic4", expectedCount);
+        AndesClient receivingClient5 = getAndesReceiverClient("topic5", expectedCount);
+        AndesClient receivingClient6 = getAndesReceiverClient("topic6", expectedCount);
+        AndesClient receivingClient7 = getAndesReceiverClient("topic7", expectedCount);
+        AndesClient receivingClient8 = getAndesReceiverClient("topic8", expectedCount);
+        AndesClient receivingClient9 = getAndesReceiverClient("topic9", expectedCount);
+        AndesClient receivingClient10 = getAndesReceiverClient("topic10", expectedCount);
 
         // Starting up receiver clients
         receivingClient1.startClient();
@@ -120,16 +126,16 @@ public class MultipleTopicTestCase extends MBPlatformBaseTest {
         receivingClient10.startClient();
 
         // Creating publisher clients
-        AndesClient sendingClient1 = getAndesSenderClient("topic1", SEND_COUNT);
-        AndesClient sendingClient2 = getAndesSenderClient("topic2", SEND_COUNT);
-        AndesClient sendingClient3 = getAndesSenderClient("topic3", SEND_COUNT);
-        AndesClient sendingClient4 = getAndesSenderClient("topic4", SEND_COUNT);
-        AndesClient sendingClient5 = getAndesSenderClient("topic5", SEND_COUNT);
-        AndesClient sendingClient6 = getAndesSenderClient("topic6", SEND_COUNT);
-        AndesClient sendingClient7 = getAndesSenderClient("topic7", SEND_COUNT);
-        AndesClient sendingClient8 = getAndesSenderClient("topic8", SEND_COUNT);
-        AndesClient sendingClient9 = getAndesSenderClient("topic9", SEND_COUNT);
-        AndesClient sendingClient10 = getAndesSenderClient("topic10", SEND_COUNT);
+        AndesClient sendingClient1 = getAndesSenderClient("topic1", sendCount);
+        AndesClient sendingClient2 = getAndesSenderClient("topic2", sendCount);
+        AndesClient sendingClient3 = getAndesSenderClient("topic3", sendCount);
+        AndesClient sendingClient4 = getAndesSenderClient("topic4", sendCount);
+        AndesClient sendingClient5 = getAndesSenderClient("topic5", sendCount);
+        AndesClient sendingClient6 = getAndesSenderClient("topic6", sendCount);
+        AndesClient sendingClient7 = getAndesSenderClient("topic7", sendCount);
+        AndesClient sendingClient8 = getAndesSenderClient("topic8", sendCount);
+        AndesClient sendingClient9 = getAndesSenderClient("topic9", sendCount);
+        AndesClient sendingClient10 = getAndesSenderClient("topic10", sendCount);
 
         // Starting up publisher clients
         sendingClient1.startClient();
@@ -166,46 +172,46 @@ public class MultipleTopicTestCase extends MBPlatformBaseTest {
 
         // Evaluating
         Assert.assertEquals(sendingClient1
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 1");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 1");
         Assert.assertEquals(sendingClient2
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 2");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 2");
         Assert.assertEquals(sendingClient3
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 3");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 3");
         Assert.assertEquals(sendingClient4
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 4");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 4");
         Assert.assertEquals(sendingClient5
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 5");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 5");
         Assert.assertEquals(sendingClient6
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 6");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 6");
         Assert.assertEquals(sendingClient7
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 7");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 7");
         Assert.assertEquals(sendingClient8
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 8");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 8");
         Assert.assertEquals(sendingClient9
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 9");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 9");
         Assert.assertEquals(sendingClient10
-                                    .getSentMessageCount(), SEND_COUNT, "Messaging sending failed in sender 10");
+                                    .getSentMessageCount(), sendCount, "Messaging sending failed in sender 10");
 
         Assert.assertEquals(receivingClient1
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 1");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 1");
         Assert.assertEquals(receivingClient2
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 2");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 2");
         Assert.assertEquals(receivingClient3
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 3");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 3");
         Assert.assertEquals(receivingClient4
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 4");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 4");
         Assert.assertEquals(receivingClient5
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 5");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 5");
         Assert.assertEquals(receivingClient6
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 6");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 6");
         Assert.assertEquals(receivingClient7
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 7");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 7");
         Assert.assertEquals(receivingClient8
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 8");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 8");
         Assert.assertEquals(receivingClient9
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 9");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 9");
         Assert.assertEquals(receivingClient10
-                                    .getReceivedMessageCount(), EXPECTED_COUNT, "Did not receive all the messages in receiving client 10");
+                                    .getReceivedMessageCount(), expectedCount, "Did not receive all the messages in receiving client 10");
 
     }
 

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/SingleSubscriberSinglePublisherTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/SingleSubscriberSinglePublisherTopicTestCase.java
@@ -21,6 +21,7 @@ package org.wso2.mb.platform.tests.clustering.topic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
@@ -37,7 +38,9 @@ import org.wso2.mb.integration.common.clients.operations.utils.AndesClientConsta
 import org.wso2.mb.integration.common.clients.exceptions.AndesClientConfigurationException;
 import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 import org.wso2.mb.integration.common.clients.operations.utils.ExchangeType;
+import org.wso2.mb.platform.common.utils.DataAccessUtil;
 import org.wso2.mb.platform.common.utils.MBPlatformBaseTest;
+import org.wso2.mb.platform.common.utils.exceptions.DataAccessUtilException;
 import org.xml.sax.SAXException;
 
 import javax.jms.JMSException;
@@ -58,6 +61,7 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
     private AutomationContext automationContextForMB2;
     private AutomationContext automationContext2;
     private TopicAdminClient topicAdminClient1;
+    private DataAccessUtil dataAccessUtil = new DataAccessUtil();
 
     /**
      * Prepare environment for tests.
@@ -96,13 +100,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Same node publisher subscriber test case",
             enabled = true)
-    public void testSameNodePubSub()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testSameNodePubSub(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                            automationContextForMB2, automationContextForMB2, 0L, 0L, "singleTopic1");
+                            automationContextForMB2, automationContextForMB2, 0L, 0L, "singleTopic1", messageCount);
     }
 
     /**
@@ -117,13 +121,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Same node publisher, slow subscriber test case",
             enabled = true)
-    public void testSameNodeSlowSubscriber()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testSameNodeSlowSubscriber(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                        automationContextForMB2, automationContextForMB2, 10L, 0L, "singleTopic2");
+                        automationContextForMB2, automationContextForMB2, 10L, 0L, "singleTopic2", messageCount);
     }
 
     /**
@@ -139,13 +143,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Same node slow publisher test case",
             enabled = true)
-    public void testSameNodeSlowPublisher()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testSameNodeSlowPublisher(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                        automationContextForMB2, automationContextForMB2, 0L, 10L, "singleTopic3");
+                        automationContextForMB2, automationContextForMB2, 0L, 10L, "singleTopic3", messageCount);
     }
 
     /**
@@ -161,13 +165,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Single node slow publisher slow subscriber test case",
             enabled = true)
-    public void testSingleNodeSlowPublisherSlowSubscriber()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testSingleNodeSlowPublisherSlowSubscriber(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                        automationContextForMB2, automationContextForMB2, 10L, 10L, "singleTopic8");
+                        automationContextForMB2, automationContextForMB2, 10L, 10L, "singleTopic8", messageCount);
     }
 
     /**
@@ -182,13 +186,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Different node publisher subscriber test case",
             enabled = true)
-    public void testDifferentNodePubSub()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testDifferentNodePubSub(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                            automationContextForMB2, automationContext2, 0L, 0L, "singleTopic10");
+                            automationContextForMB2, automationContext2, 0L, 0L, "singleTopic10", messageCount);
     }
 
     /**
@@ -204,13 +208,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Different node slow subscriber test case",
             enabled = true)
-    public void testDifferentNodeSlowSubscriber()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testDifferentNodeSlowSubscriber(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                            automationContextForMB2, automationContext2, 10L, 0L, "singleTopic5");
+                            automationContextForMB2, automationContext2, 10L, 0L, "singleTopic5", messageCount);
     }
 
     /**
@@ -226,13 +230,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Different node slow publisher test case",
             enabled = true)
-    public void testDifferentNodeSlowPublisher()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testDifferentNodeSlowPublisher(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                            automationContextForMB2, automationContext2, 0L, 10L, "singleTopic6");
+                            automationContextForMB2, automationContext2, 0L, 10L, "singleTopic6", messageCount);
     }
 
     /**
@@ -248,13 +252,13 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
      */
     @Test(groups = "wso2.mb", description = "Different node slow publisher slow subscriber test " +
                                             "case", enabled = true)
-    public void testDifferentNodeSlowPublisherSlowSubscriber()
-            throws TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientConfigurationException,
-                   XPathExpressionException, NamingException, JMSException, IOException,
-                   AndesClientException {
+    @Parameters({"messageCount"})
+    public void testDifferentNodeSlowPublisherSlowSubscriber(long messageCount)
+            throws TopicManagerAdminServiceEventAdminExceptionException, AndesClientConfigurationException,
+                   XPathExpressionException, NamingException, JMSException, IOException, AndesClientException,
+                   DataAccessUtilException {
         this.runSingleSubscriberSinglePublisherTopicTestCase(
-                            automationContextForMB2, automationContext2, 10L, 10L, "singleTopic7");
+                            automationContextForMB2, automationContext2, 10L, 10L, "singleTopic7", messageCount);
     }
 
     /**
@@ -297,14 +301,15 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
     private void runSingleSubscriberSinglePublisherTopicTestCase(
             AutomationContext contextForConsumer,
             AutomationContext contextForPublisher, long consumerDelay,
-            long publisherDelay, String destinationName)
+            long publisherDelay, String destinationName, long messageCount)
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   XPathExpressionException, TopicManagerAdminServiceEventAdminExceptionException,
-                   AndesClientException {
+                   XPathExpressionException, TopicManagerAdminServiceEventAdminExceptionException, AndesClientException,
+                   DataAccessUtilException {
         // Number of messages expected
-        long expectedCount = 2000L;
+        long expectedCount = messageCount;
         // Number of messages send
-        long sendCount = 2000L;
+        long sendCount = messageCount;
+        long printDivider = 10L;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
@@ -315,8 +320,8 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
                                                                                  .getPorts()
                                                                                  .get("amqp")),
                                                         ExchangeType.TOPIC, destinationName);
-        consumerConfig.setMaximumMessagesToReceived(expectedCount);
-        consumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
+        consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
+        consumerConfig.setPrintsPerMessageCount(expectedCount / printDivider);
         consumerConfig.setRunningDelay(consumerDelay);
 
         // Creating clients
@@ -338,7 +343,7 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
                                                                                   .get("amqp")),
                                                          ExchangeType.TOPIC, destinationName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
-        publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
+        publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
         publisherConfig.setRunningDelay(publisherDelay);
 
 
@@ -349,9 +354,12 @@ public class SingleSubscriberSinglePublisherTopicTestCase extends MBPlatformBase
                 .waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
 
         // Evaluating
-        Assert.assertEquals(publisherClient
-                                    .getSentMessageCount(), sendCount, "Message sending failed.");
-        Assert.assertEquals(consumerClient
-                                    .getReceivedMessageCount(), expectedCount, "Message receiving failed.");
+        Assert.assertEquals(publisherClient.getSentMessageCount(), sendCount, "Message sending failed.");
+        Assert.assertEquals(consumerClient.getReceivedMessageCount(), expectedCount, "Message receiving failed.");
+
+        // Evaluate messages left in database
+        Assert.assertEquals(dataAccessUtil.getMessageCountForQueue(destinationName), 0, "Messages left in database");
+        // Evaluate slots left in database
+        Assert.assertEquals(dataAccessUtil.getAssignedSlotCountForQueue(destinationName), 0, "Slots left in database");
     }
 }

--- a/modules/integration/tests-platform/tests-clustering/src/test/resources/testng.xml
+++ b/modules/integration/tests-platform/tests-clustering/src/test/resources/testng.xml
@@ -20,6 +20,8 @@
 
 <suite name="transport-test-suite">
     <parameter name="useDefaultListeners" value="false"/>
+    <parameter name="messageCount" value="1000" />
+
     <test name="tests-transports" preserve-order="true" parallel="false">
 
         <classes>
@@ -42,7 +44,7 @@
             <class name="org.wso2.mb.platform.tests.clustering.durable.topic.DurableTopicMessageDeliveringTestCase"/>
             <class name="org.wso2.mb.platform.tests.clustering.durable.topic.DurableTopicSubscriptionTestCase"/>
             <class name="org.wso2.mb.platform.tests.clustering.topic.TopicClusterTestCase"/>
-            
+
             <!-- MQTT Test Cases -->
              <class name="org.wso2.mb.platform.tests.clustering.mqtt.ClusteredSecurityTestCase"/>
               <class name="org.wso2.mb.platform.tests.clustering.mqtt.MQTTClusterTestCase"/>

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,11 @@
                 <artifactId>org.wso2.carbon.metrics.impl</artifactId>
                 <version>${carbon.metrics.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>mysql</groupId>
+                <artifactId>mysql-connector-java</artifactId>
+                <version>${mysql.connector.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -447,6 +451,7 @@
         <org.apache.commons.version>3.3.2</org.apache.commons.version>
         <jacoco.agent.version>0.7.4.201502262128</jacoco.agent.version>
         <cipher.tool.version>1.0.0-wso2v3</cipher.tool.version>
+        <mysql.connector.version>5.1.36</mysql.connector.version>
     </properties>
 
     <build>


### PR DESCRIPTION
JIRA - https://wso2.org/jira/browse/MB-1197

This PR contains modified cluster test cases with automated database assertion and message count configuration feature.

* Automate Database Assertion
At the end of each test case, database will be validated for any undelivered/left messages or invalid slots.

Before running cluster tests, we need to configure JDBC URL, Database username and password in product-mb/modules/integration/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/RDBMSConnectionManager.java

* Message Count Configuration
This feature allows configuring global parameter which will be used by test cases to send/receive configured number of messages.

Message count can be configured using <parameter name="messageCount" value="1000" /> in
product-mb/modules/integration/tests-platform/tests-clustering/src/test/resources/automation.xml