### PR TITLE
Modified DLCQueue Test Case

### DIFF
--- a/modules/integration/tests-ui-integration/src/test/resources/testng-server-mgt.xml
+++ b/modules/integration/tests-ui-integration/src/test/resources/testng-server-mgt.xml
@@ -31,7 +31,7 @@
         <classes>
             <class name="org.wso2.carbon.mb.ui.test.login.LoginTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.queues.BrowseQueueContentTestCase"/>
-            <!--<class name="org.wso2.carbon.mb.ui.test.dlc.DLCQueueTestCase"/>-->
+            <class name="org.wso2.carbon.mb.ui.test.dlc.DLCQueueTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.dlc.DLCDurableTopicTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.configure.UserStoreManagementTestCase"/>
             <class name="org.wso2.carbon.mb.ui.test.queues.QueueDeleteTestCase"/>


### PR DESCRIPTION
Addresses the jira https://wso2.org/jira/browse/MB-1218

DLCQueueTestCase was written in such a was that rather that the restoring functionality was tested by matching the id of the first message in the content table against the restored message id. It was modified to check the existence of the message id in the content table by this PR.