### PR TITLE
[MB-1219] Change ui/integration tests according to port offset

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSClientConfiguration.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSClientConfiguration.java
@@ -157,6 +157,21 @@ public class AndesJMSClientConfiguration implements Cloneable {
     }
 
     /**
+     * Creates a connection string with a given port, username, password, exchange type
+     * and destination name.
+     *
+     * @param userName        The username to be used in creating the connection string.
+     * @param password        The password to be used in creating the connection string.
+     * @param exchangeType    The exchange type.
+     * @param destinationName The destination name.
+     */
+    public AndesJMSClientConfiguration(int port, String userName, String password,ExchangeType exchangeType,
+                                       String destinationName) {
+        this(userName, password, AndesClientConstants.DEFAULT_HOST_NAME,
+                                       port, exchangeType, destinationName);
+    }
+
+    /**
      * Creates a connection string with a given username, password, hostname, port, exchange type
      * and destination name.
      *

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSClientConfiguration.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSClientConfiguration.java
@@ -128,6 +128,20 @@ public class AndesJMSClientConfiguration implements Cloneable {
     }
 
     /**
+     * Creates a connection string with default username, password, hostname and a given port. Also
+     * sets exchangeType and destination name used for publishing/consuming jms messages.
+     *
+     * @param port            The port used in the AMQP transport connection string.
+     * @param exchangeType    The exchange type used for publishing/consuming jms messages.
+     * @param destinationName The destination name used for publishing/consuming jms messages.
+     */
+    public AndesJMSClientConfiguration(int port, ExchangeType exchangeType,
+                                       String destinationName) {
+        this(AndesClientConstants.DEFAULT_USERNAME, AndesClientConstants.DEFAULT_PASSWORD,
+                            AndesClientConstants.DEFAULT_HOST_NAME, port, exchangeType, destinationName);
+    }
+
+    /**
      * Creates a connection string with a given username, password, exchange type
      * and destination name.
      *

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSConsumerClientConfiguration.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSConsumerClientConfiguration.java
@@ -141,7 +141,7 @@ public class AndesJMSConsumerClientConfiguration extends AndesJMSClientConfigura
 
 
     /**
-     * Creates a consumer with a given user name, password, for connection
+     * Creates a consumer with a given username, password, for connection
      * string and exchange type and destination name.
      *
      * @param userName        The user name for the connection string.
@@ -154,6 +154,22 @@ public class AndesJMSConsumerClientConfiguration extends AndesJMSClientConfigura
                                                String destinationName) {
         super(userName, password, exchangeType, destinationName);
     }
+
+    /**
+     * Creates a consumer with a given port, username, password, for connection
+     * string and exchange type and destination name.
+     *
+     * @param userName        The user name for the connection string.
+     * @param password        The password for the connection string.
+     * @param exchangeType    The exchange type.
+     * @param destinationName The destination name.
+     */
+    public AndesJMSConsumerClientConfiguration(int port, String userName, String password,
+                                               ExchangeType exchangeType,
+                                               String destinationName) {
+        super(port, userName, password, exchangeType, destinationName);
+    }
+
 
     /**
      * Creates a consumer with a given user name, password, host name, port for connection

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSConsumerClientConfiguration.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSConsumerClientConfiguration.java
@@ -126,6 +126,21 @@ public class AndesJMSConsumerClientConfiguration extends AndesJMSClientConfigura
     }
 
     /**
+     * Creates a consumer with a given port for connection string and exchange type and
+     * destination name.
+     *
+     * @param port            The port for the connection string.
+     * @param exchangeType    The exchange type.
+     * @param destinationName The destination name.
+     */
+    public AndesJMSConsumerClientConfiguration( int port,
+                                               ExchangeType exchangeType,
+                                               String destinationName) {
+        super(port, exchangeType, destinationName);
+    }
+
+
+    /**
      * Creates a consumer with a given user name, password, for connection
      * string and exchange type and destination name.
      *

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSPublisherClientConfiguration.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSPublisherClientConfiguration.java
@@ -97,6 +97,20 @@ public class AndesJMSPublisherClientConfiguration extends AndesJMSClientConfigur
     }
 
     /**
+     * Creates a publisher with a given host name, port for connection string and exchange type and
+     * destination name.
+     *
+     * @param port            The port for the connection string.
+     * @param exchangeType    The exchange type.
+     * @param destinationName The destination name.
+     */
+    public AndesJMSPublisherClientConfiguration(int port,
+                                                ExchangeType exchangeType,
+                                                String destinationName) {
+        super(port, exchangeType, destinationName);
+    }
+
+    /**
      * Creates a publisher with a given user name, password, for connection
      * string and exchange type and destination name.
      *

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSPublisherClientConfiguration.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/configurations/AndesJMSPublisherClientConfiguration.java
@@ -111,7 +111,7 @@ public class AndesJMSPublisherClientConfiguration extends AndesJMSClientConfigur
     }
 
     /**
-     * Creates a publisher with a given user name, password, for connection
+     * Creates a publisher with a given username, password, for connection
      * string and exchange type and destination name.
      *
      * @param userName        The user name for the connection string.
@@ -123,6 +123,21 @@ public class AndesJMSPublisherClientConfiguration extends AndesJMSClientConfigur
                                                ExchangeType exchangeType,
                                                String destinationName) {
         super(userName, password, exchangeType, destinationName);
+    }
+
+    /**
+     * Creates a publisher with a given port, username, password, for connection
+     * string and exchange type and destination name.
+     *
+     * @param userName        The user name for the connection string.
+     * @param password        The password for the connection string.
+     * @param exchangeType    The exchange type.
+     * @param destinationName The destination name.
+     */
+    public AndesJMSPublisherClientConfiguration(int port, String userName, String password,
+                                                ExchangeType exchangeType,
+                                                String destinationName) {
+        super(port, userName, password, exchangeType, destinationName);
     }
 
     /**

--- a/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/backend/MBIntegrationBaseTest.java
+++ b/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/backend/MBIntegrationBaseTest.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.xml.sax.SAXException;
 
 import javax.xml.stream.XMLStreamException;
+import javax.xml.xpath.XPathException;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.io.IOException;
@@ -83,4 +84,48 @@ public class MBIntegrationBaseTest {
         serverManager = new ServerConfigurationManager(automationContext);
         serverManager.restartGracefully();
     }
+
+    /**
+     * Returns wso2 https server port based on automation.xml configurations
+     * @throws Exception
+     */
+    protected Integer getHttpsServerPort() throws XPathExpressionException {
+        return Integer.parseInt(automationContext.getInstance().getPorts().get("https"));
+
+    }
+
+    /**
+     * Returns AMQP port based on automation.xml configurations
+     * @throws Exception
+     */
+    protected Integer getAMQPPort() throws XPathExpressionException {
+        return Integer.parseInt(automationContext.getInstance().getPorts().get("amqp"));
+
+    }
+
+    /**
+     * Returns MQTT port based on automation.xml configurations
+     * @throws Exception
+     */
+    protected Integer getMQTTPort() throws XPathExpressionException {
+        return Integer.parseInt(automationContext.getInstance().getPorts().get("mqtt"));
+    }
+
+    /**
+     * Returns JMX RMI Server port based on automation.xml configurations
+     * @throws Exception
+     */
+    protected Integer getJMXServerPort() throws XPathExpressionException {
+        return Integer.parseInt(automationContext.getInstance().getPorts().get("jmxserver"));
+    }
+
+    /**
+     * Returns JMX RMI Registry port based on automation.xml configurations
+     * @throws Exception
+     */
+    protected Integer getRMIRegistryPort() throws XPathExpressionException {
+        return Integer.parseInt(automationContext.getInstance().getPorts().get("rmiregistry"));
+    }
+
+
 }

--- a/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/backend/MBIntegrationBaseTest.java
+++ b/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/backend/MBIntegrationBaseTest.java
@@ -104,6 +104,16 @@ public class MBIntegrationBaseTest {
     }
 
     /**
+     * Returns AMQP port based on automation.xml configurations
+     * @throws Exception
+     */
+    protected Integer getSecureAMQPPort() throws XPathExpressionException {
+        return Integer.parseInt(automationContext.getInstance().getPorts().get("sslamqp"));
+
+    }
+
+
+    /**
      * Returns MQTT port based on automation.xml configurations
      * @throws Exception
      */

--- a/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/backend/MBIntegrationUiBaseTest.java
+++ b/modules/integration/tests-common/integration-tests-utils/src/main/java/org/wso2/mb/integration/common/utils/backend/MBIntegrationUiBaseTest.java
@@ -210,4 +210,20 @@ public class MBIntegrationUiBaseTest {
         driver.findElement(By.xpath(UIElementMapper.getInstance().getElement("home.mb.sign.out.xpath"))).click();
         return new LoginPage(driver);
     }
+
+    /**
+     * Returns MQTT port based on automation.xml configurations
+     * @throws XPathExpressionException
+     */
+    protected Integer getMQTTPort() throws XPathExpressionException {
+        return Integer.parseInt(mbServer.getInstance().getPorts().get("mqtt"));
+    }
+
+    /**
+     * Returns MQTT port based on automation.xml configurations
+     * @throws XPathExpressionException
+     */
+    protected Integer getAMQPPort() throws XPathExpressionException {
+        return Integer.parseInt(mbServer.getInstance().getPorts().get("amqp"));
+    }
 }

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/AutoAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/AutoAcknowledgementsTestCase.java
@@ -78,10 +78,11 @@ public class AutoAcknowledgementsTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "queue"}, description = "Single queue send-receive test case with auto Ack")
     public void autoAcknowledgementsTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a JMS consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "autoAckTestQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "autoAckTestQueue");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
@@ -125,15 +126,15 @@ public class AutoAcknowledgementsTestCase extends MBIntegrationBaseTest {
     public void autoAcknowledgementsDropReceiverTestCase()
             throws AndesClientConfigurationException, CloneNotSupportedException, JMSException,
                    NamingException,
-                   IOException, AndesClientException {
+                   IOException, AndesClientException, XPathExpressionException {
 
         // Creating a initial JMS consumer client configuration
-        AndesJMSConsumerClientConfiguration initialConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "autoAckTestQueueDropReceiver");
+        AndesJMSConsumerClientConfiguration initialConsumerConfig = new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "autoAckTestQueueDropReceiver");
         initialConsumerConfig.setMaximumMessagesToReceived(1000L);
         initialConsumerConfig.setPrintsPerMessageCount(1000L / 10L);
 
         // Creating a JMS publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "autoAckTestQueueDropReceiver");
+        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "autoAckTestQueueDropReceiver");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 
@@ -151,7 +152,7 @@ public class AutoAcknowledgementsTestCase extends MBIntegrationBaseTest {
         log.info("Messages received by first client : " + totalMessagesReceived);
 
         // Creating a secondary JMS publisher client configuration
-        AndesJMSConsumerClientConfiguration consumerConfigForClientAfterDrop = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "autoAckTestQueueDropReceiver");
+        AndesJMSConsumerClientConfiguration consumerConfigForClientAfterDrop = new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "autoAckTestQueueDropReceiver");
         consumerConfigForClientAfterDrop.setMaximumMessagesToReceived(EXPECTED_COUNT - 1000L);
 
         // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/ClientAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/ClientAcknowledgementsTestCase.java
@@ -81,11 +81,11 @@ public class ClientAcknowledgementsTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "queue"})
     public void performClientAcknowledgementsTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "clientAckTestQueue");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "clientAckTestQueue");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig
                 .setAcknowledgeMode(JMSAcknowledgeMode.CLIENT_ACKNOWLEDGE); // using client acknowledgement
@@ -95,7 +95,7 @@ public class ClientAcknowledgementsTestCase extends MBIntegrationBaseTest {
 
         // Creating a JMS publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "clientAckTestQueue");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "clientAckTestQueue");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DifferentSubscriptionsWithDurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DifferentSubscriptionsWithDurableTopicTestCase.java
@@ -69,37 +69,44 @@ public class DifferentSubscriptionsWithDurableTopicTestCase extends MBIntegratio
     public void performDifferentTopicSubscriptionsWithDurableTopicTest()
             throws AndesClientConfigurationException, CloneNotSupportedException, JMSException,
                    NamingException,
-                   IOException, AndesClientException {
+                   IOException, AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configurations
-        AndesJMSConsumerClientConfiguration durableTopicConsumerConfig1 = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, TOPIC_NAME);
+        AndesJMSConsumerClientConfiguration durableTopicConsumerConfig1 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, TOPIC_NAME);
         durableTopicConsumerConfig1.setMaximumMessagesToReceived(EXPECTED_COUNT);
         durableTopicConsumerConfig1.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
         durableTopicConsumerConfig1.setDurable(true, "diffSub1"); // durable topic
 
-        AndesJMSConsumerClientConfiguration durableTopicConsumerConfig2 = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, TOPIC_NAME);
+        AndesJMSConsumerClientConfiguration durableTopicConsumerConfig2 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, TOPIC_NAME);
         durableTopicConsumerConfig2.setMaximumMessagesToReceived(EXPECTED_COUNT);
         durableTopicConsumerConfig2.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
         durableTopicConsumerConfig2.setDurable(true, "diffSub2"); // durable topic
 
-        AndesJMSConsumerClientConfiguration normalTopicConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, TOPIC_NAME);
+        AndesJMSConsumerClientConfiguration normalTopicConsumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, TOPIC_NAME);
         normalTopicConsumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         normalTopicConsumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
-        AndesJMSConsumerClientConfiguration normalHierarchicalTopicConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, HIERARCHICAL_TOPIC);
+        AndesJMSConsumerClientConfiguration normalHierarchicalTopicConsumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, HIERARCHICAL_TOPIC);
         normalHierarchicalTopicConsumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         normalHierarchicalTopicConsumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
-        AndesJMSConsumerClientConfiguration durableHierarchicalTopicConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, HIERARCHICAL_TOPIC);
+        AndesJMSConsumerClientConfiguration durableHierarchicalTopicConsumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, HIERARCHICAL_TOPIC);
         durableHierarchicalTopicConsumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         durableHierarchicalTopicConsumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
         durableHierarchicalTopicConsumerConfig.setDurable(true, "diffSub3"); // durable topic
 
-        AndesJMSConsumerClientConfiguration queueConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, TOPIC_NAME); // queue consumer
+        AndesJMSConsumerClientConfiguration queueConsumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, TOPIC_NAME); // queue consumer
         queueConsumerConfig.setMaximumMessagesToReceived(10L);  // To wait if any message does received
 
         // Creating a publisher client configurations
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, TOPIC_NAME);
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, TOPIC_NAME);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DuplicatesOkAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DuplicatesOkAcknowledgementsTestCase.java
@@ -79,15 +79,17 @@ public class DuplicatesOkAcknowledgementsTestCase extends MBIntegrationBaseTest 
     @Test(groups = {"wso2.mb", "queue"}, description = "Single queue send-receive test case with dup messages")
     public void duplicatesOkAcknowledgementsTest()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a initial JMS consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "dupOkAckTestQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "dupOkAckTestQueue");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.DUPS_OK_ACKNOWLEDGE);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "dupOkAckTestQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "dupOkAckTestQueue");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableMultipleTopicSubscriberTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableMultipleTopicSubscriberTestCase.java
@@ -73,11 +73,11 @@ public class DurableMultipleTopicSubscriberTestCase extends MBIntegrationBaseTes
     @Test(groups = {"wso2.mb", "durableTopic"})
     public void performMultipleDurableTopicTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a first JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicMultiple");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicMultiple");
         consumerConfig1
                 .setMaximumMessagesToReceived(EXPECTED_COUNT + 10L); // if messages received more than expected
         consumerConfig1.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
@@ -85,14 +85,14 @@ public class DurableMultipleTopicSubscriberTestCase extends MBIntegrationBaseTes
 
         // Creating a second JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig2 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicMultiple");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicMultiple");
         consumerConfig2
                 .setMaximumMessagesToReceived(EXPECTED_COUNT + 10L); // if messages received more than expected
         consumerConfig2.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
         consumerConfig2.setDurable(true, "multipleSub2");
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicMultiple");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicMultiple");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicServerRestartTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicServerRestartTestCase.java
@@ -80,11 +80,11 @@ public class DurableTopicServerRestartTestCase extends MBIntegrationBaseTest {
             throws Exception {
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableServerRestartTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableServerRestartTopic");
         consumerConfig.setDurable(true, "restartServerSub");
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableServerRestartTopic");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableServerRestartTopic");
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicSubscriptionTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicSubscriptionTestCase.java
@@ -18,23 +18,38 @@
 
 package org.wso2.mb.integration.tests.amqp.functional;
 
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.mb.integration.common.clients.AndesClient;
 import org.wso2.mb.integration.common.clients.configurations.AndesJMSConsumerClientConfiguration;
 import org.wso2.mb.integration.common.clients.exceptions.AndesClientConfigurationException;
 import org.wso2.mb.integration.common.clients.exceptions.AndesClientException;
 import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 import org.wso2.mb.integration.common.clients.operations.utils.ExchangeType;
+import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
 import javax.jms.JMSException;
 import javax.naming.NamingException;
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 
 /**
  * This class holds set of test cases to verify if durable topic subscriptions happen according to
  * spec.
  */
-public class DurableTopicSubscriptionTestCase {
+public class DurableTopicSubscriptionTestCase extends MBIntegrationBaseTest {
+
+
+    /**
+     * Initializing test case
+     *
+     * @throws javax.xml.xpath.XPathExpressionException
+     */
+    @BeforeClass
+    public void prepare() throws XPathExpressionException {
+        init(TestUserMode.SUPER_TENANT_ADMIN);
+    }
 
     /**
      * Creating a client with a subscription ID and unSubscribe it and create another client with
@@ -49,11 +64,11 @@ public class DurableTopicSubscriptionTestCase {
     @Test(groups = {"wso2.mb", "topic"})
     public void subscribeDisconnectAndSubscribeAgainTest()
             throws JMSException, NamingException, AndesClientConfigurationException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic1");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic1");
         consumerConfig.setDurable(true, "durableSub1");
 
         // Creating clients
@@ -92,10 +107,10 @@ public class DurableTopicSubscriptionTestCase {
             expectedExceptionsMessageRegExp = ".*Cannot subscribe to queue .* as it already has an existing exclusive consumer.*")
     public void multipleSubsWithSameIdTest()
             throws JMSException, NamingException, IOException, AndesClientConfigurationException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic2");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic2");
         consumerConfig.setDurable(true, "sriLanka");
 
         // Creating clients
@@ -129,11 +144,11 @@ public class DurableTopicSubscriptionTestCase {
     @Test(groups = {"wso2.mb", "topic"})
     public void multipleSubsWithDifferentIdTest()
             throws JMSException, NamingException, AndesClientConfigurationException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic3");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic3");
         consumerConfig.setDurable(true, "test1");
 
         AndesJMSConsumerClientConfiguration secondaryConsumerConfig = consumerConfig.clone();
@@ -173,11 +188,11 @@ public class DurableTopicSubscriptionTestCase {
     @Test(groups = {"wso2.mb", "topic"}, expectedExceptions = javax.jms.JMSException.class, expectedExceptionsMessageRegExp = ".*An Exclusive Bindings already exists for different topic.*")
     public void multipleSubsToDifferentTopicsWithSameSubIdTest()
             throws JMSException, NamingException, AndesClientConfigurationException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic4");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic4");
         consumerConfig.setDurable(true, "test3");
 
         // Creating clients
@@ -214,11 +229,11 @@ public class DurableTopicSubscriptionTestCase {
     @Test(groups = {"wso2.mb", "topic"})
     public void durableTopicWithNormalTopicTest()
             throws JMSException, NamingException, AndesClientConfigurationException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic5");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic5");
         consumerConfig.setDurable(true, "test5");
 
         // Creating clients
@@ -228,7 +243,7 @@ public class DurableTopicSubscriptionTestCase {
         AndesClientUtils.sleepForInterval(2000L);
 
         AndesJMSConsumerClientConfiguration secondConsumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic5");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic5");
         AndesClient secondaryConsumerClient = new AndesClient(secondConsumerConfig, true);
         secondaryConsumerClient.startClient();
 
@@ -256,10 +271,11 @@ public class DurableTopicSubscriptionTestCase {
     @Test(groups = {"wso2.mb", "topic"})
     public void multipleSubsWithDiffIDsToSameTopicTest()
             throws JMSException, NamingException, AndesClientConfigurationException,
-                   CloneNotSupportedException, IOException, AndesClientException {
+                   CloneNotSupportedException, IOException, AndesClientException,
+                   XPathExpressionException {
         // Creating configurations
         AndesJMSConsumerClientConfiguration firstConsumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "multiSubTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "multiSubTopic");
         firstConsumerConfig.setDurable(true, "new1");
 
         AndesJMSConsumerClientConfiguration secondConsumerConfig = firstConsumerConfig.clone();
@@ -315,15 +331,15 @@ public class DurableTopicSubscriptionTestCase {
     @Test(groups = {"wso2.mb", "topic"})
     public void subscribeUnSubscribeAndTryDifferentTopicTest()
             throws JMSException, NamingException, IOException, AndesClientConfigurationException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating configurations
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic8");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic8");
         consumerConfig.setDurable(true, "test8");
 
         AndesJMSConsumerClientConfiguration secondaryConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "myTopic9");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "myTopic9");
         secondaryConfig.setDurable(true, "test8");
 
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicSubscriptionWithSameClientIdTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicSubscriptionWithSameClientIdTestCase.java
@@ -91,13 +91,13 @@ public class DurableTopicSubscriptionWithSameClientIdTestCase extends MBIntegrat
 
         // Creating a JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicSameClientID");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicSameClientID");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setDurable(true, "sameClientIDSub1");
 
         // Creating a JMS consumer client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicSameClientID");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicSameClientID");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT_12);
 
         // Creating clients
@@ -146,22 +146,22 @@ public class DurableTopicSubscriptionWithSameClientIdTestCase extends MBIntegrat
 
         // Creating a JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicSameClientIDTopic1");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicSameClientIDTopic1");
         consumerConfig1.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig1.setDurable(true, "sameClientIDSub2");
 
         AndesJMSConsumerClientConfiguration consumerConfig2 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicSameClientIDTopic2");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicSameClientIDTopic2");
         consumerConfig2.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig2.setDurable(true, "sameClientIDSub3");
 
         // Creating a JMS consumer client configuration
         AndesJMSPublisherClientConfiguration publisherConfig1 =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicSameClientIDTopic1");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicSameClientIDTopic1");
         publisherConfig1.setNumberOfMessagesToSend(SEND_COUNT_12);
 
         AndesJMSPublisherClientConfiguration publisherConfig2 =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicSameClientIDTopic2");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicSameClientIDTopic2");
         publisherConfig2.setNumberOfMessagesToSend(SEND_COUNT_8);
 
         // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicTestCase.java
@@ -81,17 +81,17 @@ public class DurableTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "durableTopic"})
     public void performDurableTopicTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicTest");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicTest");
         consumerConfig1.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig1.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
         consumerConfig1.setDurable(true, "durableSubToDurableTopic1");
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicTest");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicTest");
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/HierarchicalTopicsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/HierarchicalTopicsTestCase.java
@@ -82,7 +82,7 @@ public class HierarchicalTopicsTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "topic"})
     public void performHierarchicalTopicsTopicOnlyTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         /**
          * topic only option. Here we subscribe to games.cricket and verify that only messages
@@ -146,7 +146,7 @@ public class HierarchicalTopicsTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "topic"})
     public void performHierarchicalTopicsImmediateChildrenTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating clients
         AndesClient consumerClient3 = getConsumerClientForTopic("games.*");
@@ -223,7 +223,7 @@ public class HierarchicalTopicsTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "topic"})
     public void performHierarchicalTopicsChildrenTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         //we should  get any message here
         AndesClient consumerClient6 = getConsumerClientForTopic("games.#");
@@ -273,10 +273,10 @@ public class HierarchicalTopicsTestCase extends MBIntegrationBaseTest {
      */
     private AndesClient getConsumerClientForTopic(String topicName)
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         // Creating a JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, topicName);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, topicName);
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
@@ -296,10 +296,10 @@ public class HierarchicalTopicsTestCase extends MBIntegrationBaseTest {
      */
     private AndesClient getPublishingClientForTopic(String topicName)
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         // Creating a JMS publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, topicName);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, topicName);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/InterTenantQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/InterTenantQueueTestCase.java
@@ -61,14 +61,15 @@ public class InterTenantQueueTestCase extends MBIntegrationBaseTest {
      * @throws javax.naming.NamingException
      */
     @Test(groups = "wso2.mb", description = "Inter tenant queue publish test case")
-    public void performSingleQueueSendReceiveTestCase() throws NamingException, JMSException {
+    public void performSingleQueueSendReceiveTestCase()
+            throws NamingException, JMSException, XPathExpressionException {
         String queueName = "testtenant1.com/tenant1queue";
         InitialContext subscriberInitialContext = JMSClientHelper
                 .getInitialContextForQueue("tenant1user1!testtenant1.com", "tenant1user1",
-                                           "localhost", "5672", queueName);
+                                           "localhost", getAMQPPort().toString(), queueName);
         InitialContext publisherInitialContext = JMSClientHelper
                 .getInitialContextForQueue("tenant2user1!testtenant2.com", "tenant2user1",
-                                           "localhost", "5672", queueName);
+                                           "localhost", getAMQPPort().toString(), queueName);
 
         // Initialize subscriber
         ConnectionFactory subscriberConnectionFactory = (ConnectionFactory) subscriberInitialContext.lookup(JMSClientHelper.QUEUE_CONNECTION_FACTORY);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionMessageReceiveOrderTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionMessageReceiveOrderTestCase.java
@@ -35,6 +35,7 @@ import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
 import javax.jms.JMSException;
 import javax.naming.NamingException;
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 
 /**
@@ -86,11 +87,11 @@ public class JMSSubscriberTransactionMessageReceiveOrderTestCase extends MBInteg
     @Test(groups = {"wso2.mb", "queue", "transactions"})
     public void performJMSSubscriberTransactionMessageReceiveOrderTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Create a initial JMS consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new
-                AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, QUEUE_DESTINATION);
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, QUEUE_DESTINATION);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.SESSION_TRANSACTED);
         consumerConfig.setCommitAfterEachMessageCount(EXPECTED_COUNT);
         consumerConfig.setRollbackAfterEachMessageCount(SEND_COUNT);
@@ -100,8 +101,8 @@ public class JMSSubscriberTransactionMessageReceiveOrderTestCase extends MBInteg
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
         // Create JMS publisher configurations
-        AndesJMSPublisherClientConfiguration publisherConfig = new
-                AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, QUEUE_DESTINATION);
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, QUEUE_DESTINATION);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         // Initialize consumer client

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionsSessionCommitRollbackTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionsSessionCommitRollbackTestCase.java
@@ -35,6 +35,7 @@ import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
 import javax.jms.JMSException;
 import javax.naming.NamingException;
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.util.Map;
 
@@ -80,10 +81,11 @@ public class JMSSubscriberTransactionsSessionCommitRollbackTestCase extends MBIn
     @Test(groups = {"wso2.mb", "queue", "transactions"})
     public void performJMSSubscriberTransactionsSessionCommitRollbackTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Creating a initial JMS consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "transactionQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "transactionQueue");
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.SESSION_TRANSACTED);
         consumerConfig.setCommitAfterEachMessageCount(EXPECTED_COUNT);
         consumerConfig.setRollbackAfterEachMessageCount(SEND_COUNT);
@@ -91,7 +93,8 @@ public class JMSSubscriberTransactionsSessionCommitRollbackTestCase extends MBIn
         consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT/10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "transactionQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "transactionQueue");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MessageContentTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MessageContentTestCase.java
@@ -84,7 +84,7 @@ public class MessageContentTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Message content validation test case")
     public void performQueueContentSendReceiveTestCase()
             throws AndesClientConfigurationException, IOException, JMSException, NamingException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Reading message content
         char[] inputContent = new char[SIZE_TO_READ];
@@ -100,17 +100,20 @@ public class MessageContentTestCase extends MBIntegrationBaseTest {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "QueueContentSendReceive");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "QueueContentSendReceive");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
+        // writing received messages.
         consumerConfig
-                .setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES); // writing received messages.
+                .setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "QueueContentSendReceive");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "QueueContentSendReceive");
+
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
+        // message content will be read from this path and published
         publisherConfig
-                .setReadMessagesFromFilePath(AndesClientConstants.MESSAGE_CONTENT_INPUT_FILE_PATH_1MB); // message content will be read from this path and published
+                .setReadMessagesFromFilePath(AndesClientConstants.MESSAGE_CONTENT_INPUT_FILE_PATH_1MB);
 
         // Creating clients
         AndesClient consumerClient = new AndesClient(consumerConfig, true);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedDurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedDurableTopicTestCase.java
@@ -95,20 +95,23 @@ public class MixedDurableTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Single durable topic send-receive test case with jms expiration")
     public void performExpiryDurableTopicTestCase()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Creating a subscriber client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "durableTopicWithExpiration");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicWithExpiration");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT_BY_ONE_SUBSCRIBER);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT_BY_ONE_SUBSCRIBER / 10L);
         consumerConfig.setDurable(true, "expirationSub");
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicWithExpiration");
+        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicWithExpiration");
         publisherConfigWithoutExpiration.setNumberOfMessagesToSend(SEND_COUNT_WITHOUT_EXPIRATION);
         publisherConfigWithoutExpiration.setPrintsPerMessageCount(SEND_COUNT_WITHOUT_EXPIRATION / 10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "durableTopicWithExpiration");
+        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "durableTopicWithExpiration");
         publisherConfigWithExpiration.setNumberOfMessagesToSend(SEND_COUNT_WITH_EXPIRATION);
         publisherConfigWithExpiration.setPrintsPerMessageCount(SEND_COUNT_WITH_EXPIRATION / 10L);
         publisherConfigWithExpiration.setJMSMessageExpiryTime(EXPIRATION_TIME); // Setting expiry time

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedQueueTestCase.java
@@ -67,7 +67,7 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Single queue send-receive test case with 50% expired messages")
     public void performSingleQueueExpirySendReceiveTestCase()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Message send count
         long sendCount = 1000L;
@@ -79,15 +79,18 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
         long expirationTime = 1L;
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "queueWithExpiration");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiration");
         consumerConfig.setMaximumMessagesToReceived(sendCountWithoutExpiration);
         consumerConfig.setPrintsPerMessageCount(sendCountWithoutExpiration / 10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "queueWithExpiration");
+        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiration");
         publisherConfigWithoutExpiration.setNumberOfMessagesToSend(sendCountWithoutExpiration);
         publisherConfigWithoutExpiration.setPrintsPerMessageCount(sendCountWithoutExpiration / 10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "queueWithExpiration");
+        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiration");
         publisherConfigWithExpiration.setNumberOfMessagesToSend(sendCountWithExpiration);
         publisherConfigWithExpiration.setPrintsPerMessageCount(sendCountWithExpiration / 10L);
         publisherConfigWithExpiration.setJMSMessageExpiryTime(expirationTime); // setting expiration time
@@ -124,7 +127,7 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "send messages to a queue which has two consumers with jms expiration")
     public void performManyQueueExpirySendReceiveTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Message send count
         long sendCount = 1000L;
@@ -138,20 +141,24 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
         long expirationTime = 1L;
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration initialConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
+        AndesJMSConsumerClientConfiguration initialConsumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
         initialConsumerConfig.setMaximumMessagesToReceived(expectedCountByOneSubscriber);
         initialConsumerConfig.setPrintsPerMessageCount(expectedCountByOneSubscriber / 10L);
 
-        AndesJMSConsumerClientConfiguration secondaryConsumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
+        AndesJMSConsumerClientConfiguration secondaryConsumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
         secondaryConsumerConfig.setMaximumMessagesToReceived(expectedCountByOneSubscriber);
         secondaryConsumerConfig.setPrintsPerMessageCount(expectedCountByOneSubscriber / 10L);
 
         // Creating a consumer client configuration
-        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
+        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
         publisherConfigWithoutExpiration.setNumberOfMessagesToSend(sendCountWithoutExpiration);
         publisherConfigWithoutExpiration.setPrintsPerMessageCount(sendCountWithoutExpiration / 10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
+        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueWithExpiryAndManyConsumers");
         publisherConfigWithExpiration.setPrintsPerMessageCount(sendCountWithExpiration / 10L);
         publisherConfigWithExpiration.setNumberOfMessagesToSend(sendCountWithExpiration);
         publisherConfigWithExpiration.setJMSMessageExpiryTime(expirationTime);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedTopicTestCase.java
@@ -93,18 +93,21 @@ public class MixedTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Single topic send-receive test case with jms expiration")
     public void performSingleExpiryTopicSendReceiveTestCase()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "topicWithExpiry");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "topicWithExpiry");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
-        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "topicWithExpiry");
+        AndesJMSPublisherClientConfiguration publisherConfigWithoutExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "topicWithExpiry");
         publisherConfigWithoutExpiration.setPrintsPerMessageCount(SEND_COUNT_WITHOUT_EXPIRATION / 10L);
         publisherConfigWithoutExpiration.setNumberOfMessagesToSend(SEND_COUNT_WITHOUT_EXPIRATION);
 
-        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "topicWithExpiry");
+        AndesJMSPublisherClientConfiguration publisherConfigWithExpiration =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "topicWithExpiry");
         publisherConfigWithExpiration.setPrintsPerMessageCount(SEND_COUNT_WITH_EXPIRATION / 10L);
         publisherConfigWithExpiration.setNumberOfMessagesToSend(SEND_COUNT_WITH_EXPIRATION);
         publisherConfigWithExpiration.setJMSMessageExpiryTime(EXPIRATION_TIME); // Setting expiry time

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantDurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantDurableTopicTestCase.java
@@ -121,7 +121,7 @@ public class MultiTenantDurableTopicTestCase extends MBIntegrationBaseTest {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration adminConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("admin!topictenant1.com", "admin",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "admin!topictenant1.com", "admin",
                         ExchangeType.TOPIC, destinationName);
         adminConsumerConfig.setUnSubscribeAfterEachMessageCount(expectedMessageCount);
         adminConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
@@ -154,7 +154,7 @@ public class MultiTenantDurableTopicTestCase extends MBIntegrationBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration tenantPublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                      "topictenantuser1", ExchangeType.TOPIC, destinationName);
         tenantPublisherConfig.setNumberOfMessagesToSend(sendMessageCount);
         tenantPublisherConfig.setPrintsPerMessageCount(sendMessageCount / 10L);
@@ -189,21 +189,21 @@ public class MultiTenantDurableTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Multiple Tenant Single Users Test")
     public void performMultipleTenantDurableTopicTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         int sendMessageCount1 = 80;
         int sendMessageCount2 = 120;
         int expectedMessageCount = 200;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration tenant1ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                 "topictenantuser1", ExchangeType.TOPIC, "topictenant1.com/multitenantTopicDurable");
         tenant1ConsumerConfig.setUnSubscribeAfterEachMessageCount(expectedMessageCount);
         tenant1ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
         tenant1ConsumerConfig.setDurable(true, "multi");
 
         AndesJMSConsumerClientConfiguration tenant2ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant2.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant2.com",
                 "topictenantuser1", ExchangeType.TOPIC, "topictenant2.com/multitenantTopicDurable");
         tenant2ConsumerConfig.setUnSubscribeAfterEachMessageCount(expectedMessageCount);
         tenant2ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
@@ -211,13 +211,13 @@ public class MultiTenantDurableTopicTestCase extends MBIntegrationBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration tenant1PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                  "topictenantuser1", ExchangeType.TOPIC, "topictenant1.com/multitenantTopicDurable");
         tenant1PublisherConfig.setNumberOfMessagesToSend(sendMessageCount1);
         tenant1PublisherConfig.setPrintsPerMessageCount(sendMessageCount1 / 10L);
 
         AndesJMSPublisherClientConfiguration tenant2PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant2.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant2.com",
                 "topictenantuser1", ExchangeType.TOPIC, "topictenant2.com/multitenantTopicDurable");
         tenant2PublisherConfig.setNumberOfMessagesToSend(sendMessageCount2);
         tenant2PublisherConfig.setPrintsPerMessageCount(sendMessageCount2 / 10L);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantQueueTestCase.java
@@ -116,7 +116,7 @@ public class MultiTenantQueueTestCase extends MBIntegrationBaseTest {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration adminConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("admin!topictenant1.com", "admin",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "admin!topictenant1.com", "admin",
                                             ExchangeType.QUEUE, destinationName);
         adminConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         adminConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
@@ -147,7 +147,7 @@ public class MultiTenantQueueTestCase extends MBIntegrationBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration tenantPublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                              "topictenantuser1", ExchangeType.QUEUE, destinationName);
         tenantPublisherConfig.setNumberOfMessagesToSend(sendMessageCount);
         tenantPublisherConfig.setPrintsPerMessageCount(sendMessageCount / 10L);
@@ -181,7 +181,7 @@ public class MultiTenantQueueTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Multiple Tenant Single Users Test")
     public void performMultipleTenantQueueTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         int sendMessageCount1 = 80;
         int sendMessageCount2 = 120;
@@ -189,26 +189,26 @@ public class MultiTenantQueueTestCase extends MBIntegrationBaseTest {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration tenant1ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                         "topictenantuser1", ExchangeType.QUEUE, "topictenant1.com/multitenantQueue");
         tenant1ConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         tenant1ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
 
         AndesJMSConsumerClientConfiguration tenant2ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant2.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant2.com",
                         "topictenantuser1", ExchangeType.QUEUE, "topictenant2.com/multitenantQueue");
         tenant2ConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         tenant2ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration tenant1PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                      "topictenantuser1", ExchangeType.QUEUE, "topictenant1.com/multitenantQueue");
         tenant1PublisherConfig.setNumberOfMessagesToSend(sendMessageCount1);
         tenant1PublisherConfig.setPrintsPerMessageCount(sendMessageCount1 / 10L);
 
         AndesJMSPublisherClientConfiguration tenant2PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant2.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant2.com",
                      "topictenantuser1", ExchangeType.QUEUE, "topictenant2.com/multitenantQueue");
         tenant2PublisherConfig.setNumberOfMessagesToSend(sendMessageCount2);
         tenant2PublisherConfig.setPrintsPerMessageCount(sendMessageCount2 / 10L);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantTopicTestCase.java
@@ -82,26 +82,26 @@ public class MultiTenantTopicTestCase extends MBIntegrationBaseTest {
             expectedExceptionsMessageRegExp = ".*Permission denied.*")
     public void performSingleTenantMultipleUserTopicTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         int sendMessageCount = 200;
         int expectedMessageCount = 200;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration adminConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("admin!topictenant1.com", "admin",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "admin!topictenant1.com", "admin",
                                                 ExchangeType.TOPIC, "topictenant1.com/tenantTopic");
         adminConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         adminConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
 
         AndesJMSConsumerClientConfiguration tenant1ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                             "topictenantuser1", ExchangeType.TOPIC, "topictenant1.com/tenantTopic");
         tenant1ConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         tenant1ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration tenant1PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("admin!topictenant1.com", "admin",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "admin!topictenant1.com", "admin",
                                                  ExchangeType.TOPIC, "topictenant1.com/tenantTopic");
         tenant1PublisherConfig.setNumberOfMessagesToSend(sendMessageCount);
         tenant1PublisherConfig.setPrintsPerMessageCount(sendMessageCount / 10L);
@@ -149,33 +149,33 @@ public class MultiTenantTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Multiple Tenant Single Users Test")
     public void performMultipleTenantTopicTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         int sendMessageCount1 = 120;
         int sendMessageCount2 = 80;
         int expectedMessageCount = 200;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration tenant1ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                         "topictenantuser1", ExchangeType.TOPIC, "topictenant1.com/multitenantTopic");
         tenant1ConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         tenant1ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
 
         AndesJMSConsumerClientConfiguration tenant2ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("topictenantuser1!topictenant2.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant2.com",
                         "topictenantuser1", ExchangeType.TOPIC, "topictenant2.com/multitenantTopic");
         tenant2ConsumerConfig.setMaximumMessagesToReceived(expectedMessageCount);
         tenant2ConsumerConfig.setPrintsPerMessageCount(expectedMessageCount / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration tenant1PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant1.com",
                     "topictenantuser1", ExchangeType.TOPIC, "topictenant1.com/multitenantTopic");
         tenant1PublisherConfig.setNumberOfMessagesToSend(sendMessageCount1);
         tenant1PublisherConfig.setPrintsPerMessageCount(sendMessageCount1 / 10L);
 
         AndesJMSPublisherClientConfiguration tenant2PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("topictenantuser1!topictenant2.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "topictenantuser1!topictenant2.com",
                      "topictenantuser1", ExchangeType.TOPIC, "topictenant2.com/multitenantTopic");
         tenant2PublisherConfig.setNumberOfMessagesToSend(sendMessageCount2);
         tenant2PublisherConfig.setPrintsPerMessageCount(sendMessageCount2 / 10L);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleQueueSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleQueueSendReceiveTestCase.java
@@ -76,10 +76,12 @@ public class MultipleQueueSendReceiveTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "queue"},enabled = false)
     public void performMultipleQueueSendReceiveTestCase()
             throws AndesClientConfigurationException, AndesClientException, JMSException,
-                   IOException, NamingException, CloneNotSupportedException {
+                   IOException, NamingException, CloneNotSupportedException,
+                   XPathExpressionException {
 
         // Creating a consumer client configurations
-        AndesJMSConsumerClientConfiguration consumerConfig1 = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "multipleQueue1");
+        AndesJMSConsumerClientConfiguration consumerConfig1 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "multipleQueue1");
         consumerConfig1.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig1.setPrintsPerMessageCount(EXPECTED_COUNT/10L);
 
@@ -87,7 +89,8 @@ public class MultipleQueueSendReceiveTestCase extends MBIntegrationBaseTest {
         consumerConfig2.setDestinationName("multipleQueue2");
 
         // Creating a publisher client configurations
-        AndesJMSPublisherClientConfiguration publisherConfig1 = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "multipleQueue1");
+        AndesJMSPublisherClientConfiguration publisherConfig1 =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "multipleQueue1");
         publisherConfig1.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig1.setPrintsPerMessageCount(SEND_COUNT/10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleTopicPublishSubscribeTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleTopicPublishSubscribeTestCase.java
@@ -75,23 +75,27 @@ public class MultipleTopicPublishSubscribeTestCase extends MBIntegrationBaseTest
     @Test(groups = {"wso2.mb", "topic"})
     public void performMultipleTopicPublishSubscribeTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configurations
-        AndesJMSConsumerClientConfiguration consumerConfig1 = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "multipleTopic2");
+        AndesJMSConsumerClientConfiguration consumerConfig1 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "multipleTopic2");
         consumerConfig1.setMaximumMessagesToReceived(EXPECTED_COUNT_4010);
         consumerConfig1.setPrintsPerMessageCount(EXPECTED_COUNT_4010 / 10);
 
-        AndesJMSConsumerClientConfiguration consumerConfig2 = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "multipleTopic1");
+        AndesJMSConsumerClientConfiguration consumerConfig2 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "multipleTopic1");
         consumerConfig2.setMaximumMessagesToReceived(EXPECTED_COUNT_1010);
         consumerConfig2.setPrintsPerMessageCount(EXPECTED_COUNT_1010 / 10);
 
         // Creating a publisher client configurations
-        AndesJMSPublisherClientConfiguration publisherConfig1 = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "multipleTopic2");
+        AndesJMSPublisherClientConfiguration publisherConfig1 =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "multipleTopic2");
         publisherConfig1.setPrintsPerMessageCount(100L);
         publisherConfig1.setNumberOfMessagesToSend(SEND_COUNT_2000);
 
-        AndesJMSPublisherClientConfiguration publisherConfig2 = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "multipleTopic1");
+        AndesJMSPublisherClientConfiguration publisherConfig2 =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "multipleTopic1");
         publisherConfig2.setPrintsPerMessageCount(100L);
         publisherConfig2.setNumberOfMessagesToSend(SEND_COUNT_1000);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/PurgeMessagesTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/PurgeMessagesTestCase.java
@@ -143,8 +143,8 @@ public class PurgeMessagesTestCase extends MBIntegrationBaseTest {
         String sessionCookie = loginLogoutClientForAdmin.login();
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig1 = new AndesJMSConsumerClientConfiguration(ExchangeType
-                .QUEUE, TEST_QUEUE_PURGE);
+        AndesJMSConsumerClientConfiguration consumerConfig1 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, TEST_QUEUE_PURGE);
         consumerConfig1.setAcknowledgeMode(JMSAcknowledgeMode.CLIENT_ACKNOWLEDGE);
         consumerConfig1.setMaximumMessagesToReceived(expectedMessageCount);
         consumerConfig1.setPrintsPerMessageCount(expectedMessageCount / 100L);
@@ -160,14 +160,14 @@ public class PurgeMessagesTestCase extends MBIntegrationBaseTest {
         consumerClient2.startClient();
 
         // Creating publisher configuration with destination queue = 'purgeTestQueue' and message count = 25
-        AndesJMSPublisherClientConfiguration publisherConfig1 = new AndesJMSPublisherClientConfiguration(ExchangeType
-                .QUEUE, TEST_QUEUE_PURGE);
+        AndesJMSPublisherClientConfiguration publisherConfig1 =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, TEST_QUEUE_PURGE);
         publisherConfig1.setNumberOfMessagesToSend(sendToPurgeQueueCount);
         publisherConfig1.setPrintsPerMessageCount(sendToPurgeQueueCount / 5L);
 
         // Creating publisher configuration with destination queue = 'deleteTestQueue' and message count = 75
-        AndesJMSPublisherClientConfiguration publisherConfig2 = new AndesJMSPublisherClientConfiguration(ExchangeType
-                .QUEUE, TEST_QUEUE_DELETE);
+        AndesJMSPublisherClientConfiguration publisherConfig2 =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, TEST_QUEUE_DELETE);
         publisherConfig2.setNumberOfMessagesToSend(sendToDeleteQueueCount);
         publisherConfig2.setPrintsPerMessageCount(sendToDeleteQueueCount / 5L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageRedeliveryWithAckTimeOutTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageRedeliveryWithAckTimeOutTestCase.java
@@ -81,19 +81,21 @@ public class QueueMessageRedeliveryWithAckTimeOutTestCase extends MBIntegrationB
     @Test(groups = {"wso2.mb", "queue"})
     public void performQueueMessageRedeliveryWithAckTimeOutTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Setting system property "AndesAckWaitTimeOut" for andes
         System.setProperty("AndesAckWaitTimeOut", Long.toString(DEFAULT_ACK_WAIT_TIMEOUT * 1000L));
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "redeliveryQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "redeliveryQueue");
         consumerConfig.setMaximumMessagesToReceived(5L);
         consumerConfig.setAcknowledgeAfterEachMessageCount(200L);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.CLIENT_ACKNOWLEDGE);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "redeliveryQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "redeliveryQueue");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageSequentialAndDuplicateTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageSequentialAndDuplicateTestCase.java
@@ -71,16 +71,19 @@ public class QueueMessageSequentialAndDuplicateTestCase extends MBIntegrationBas
     @Test(groups = {"wso2.mb", "queue"})
     public void performQueueMessageSequentialAndDuplicateTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "singleQueueDuplication");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueueDuplication");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT + 10L);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
-        consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES); // writing received messages to a file
+        // writing received messages to a file
+        consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "singleQueueDuplication");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueueDuplication");
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueSubscriptionsBreakAndReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueSubscriptionsBreakAndReceiveTestCase.java
@@ -86,15 +86,17 @@ public class QueueSubscriptionsBreakAndReceiveTestCase extends MBIntegrationBase
     @Test(groups = {"wso2.mb", "queue"})
     public void performQueueSubscriptionsBreakAndReceiveTestCase()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   CloneNotSupportedException, AndesClientException {
+                   CloneNotSupportedException, AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "breakSubscriberQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "breakSubscriberQueue");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT_BY_EACH_SUBSCRIBER);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT_BY_EACH_SUBSCRIBER / 10L);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "breakSubscriberQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "breakSubscriberQueue");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueTestCase.java
@@ -67,18 +67,20 @@ public class QueueTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Single queue send-receive test case")
     public void performSingleQueueSendReceiveTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         long sendCount = 1000L;
         long expectedCount = 1000L;
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "singleQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueue");
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "singleQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueue");
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
 
@@ -113,17 +115,19 @@ public class QueueTestCase extends MBIntegrationBaseTest {
                                             " as queue")
     public void performSubTopicPubQueueTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         long sendCount = 1000L;
         long expectedCount = 1000L;
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "subTopicPubQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "subTopicPubQueue");
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "subTopicPubQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "subTopicPubQueue");
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
 
@@ -155,22 +159,25 @@ public class QueueTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "send large number of messages to a queue which has two consumers")
     public void performManyConsumersTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         long sendCount = 3000L;
         long expectedCount = 3000L;
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig1 = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "queueManyConsumers");
+        AndesJMSConsumerClientConfiguration consumerConfig1 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueManyConsumers");
         consumerConfig1.setMaximumMessagesToReceived(expectedCount);
         consumerConfig1.setPrintsPerMessageCount(expectedCount / 10L);
 
         // Creating a publisher client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig2 = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "queueManyConsumers");
+        AndesJMSConsumerClientConfiguration consumerConfig2 =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueManyConsumers");
         consumerConfig2.setMaximumMessagesToReceived(expectedCount);
         consumerConfig2.setPrintsPerMessageCount(100L);
 
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "queueManyConsumers");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "queueManyConsumers");
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(100L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueUserAuthorizationTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueUserAuthorizationTestCase.java
@@ -497,14 +497,14 @@ public class QueueUserAuthorizationTestCase extends MBIntegrationBaseTest {
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration
                 consumerConfig =
-                new AndesJMSConsumerClientConfiguration(
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
                         contextUser.getUserNameWithoutDomain(), contextUser.getPassword(),
                         ExchangeType.QUEUE, destinationName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
                         contextUser.getUserNameWithoutDomain(), contextUser.getPassword(),
                         ExchangeType.QUEUE, destinationName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SSLSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SSLSendReceiveTestCase.java
@@ -79,7 +79,7 @@ public class SSLSendReceiveTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "queue", "security"})
     public void performSingleQueueSendReceiveTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         // Creating ssl connection string elements
         // The following keystore path and truststore path should be as follows regardless the OS(platform).
         String keyStorePath = System.getProperty("carbon.home").replace("\\", "/") + "/repository/resources/security/" +
@@ -92,7 +92,7 @@ public class SSLSendReceiveTestCase extends MBIntegrationBaseTest {
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
                 new AndesJMSConsumerClientConfiguration(
-                        "admin", "admin", "127.0.0.1", 8672, ExchangeType.QUEUE, "SSLSingleQueue",
+                        "admin", "admin", "127.0.0.1", getSecureAMQPPort(), ExchangeType.QUEUE, "SSLSingleQueue",
                         "RootCA", trustStorePath, trustStorePassword, keyStorePath,
                         keyStorePassword);
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
@@ -101,7 +101,7 @@ public class SSLSendReceiveTestCase extends MBIntegrationBaseTest {
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
                 new AndesJMSPublisherClientConfiguration(
-                        "admin", "admin", "127.0.0.1", 8672, ExchangeType.QUEUE, "SSLSingleQueue",
+                        "admin", "admin", "127.0.0.1", getSecureAMQPPort(), ExchangeType.QUEUE, "SSLSingleQueue",
                         "RootCA", trustStorePath, trustStorePassword, keyStorePath,
                         keyStorePassword);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SelectorsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SelectorsTestCase.java
@@ -78,17 +78,19 @@ public class SelectorsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "send-receive test case with jms selectors without conforming messages")
     public void performQueueSendWithReceiverHavingSelectorsButNoModifiedPublisherSelectors()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberJMSType");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE, "jmsSelectorSubscriberJMSType");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setSelectors("JMSType='AAA'");
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberJMSType");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE, "jmsSelectorSubscriberJMSType");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         // Creating clients
@@ -122,17 +124,19 @@ public class SelectorsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb")
     public void performQueueSendWithModifiedPublisherSelectors()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberAndPublisherJMSType");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE, "jmsSelectorSubscriberAndPublisherJMSType");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setSelectors("JMSType='AAA'");
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberAndPublisherJMSType");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE, "jmsSelectorSubscriberAndPublisherJMSType");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         // Creating clients
@@ -174,18 +178,20 @@ public class SelectorsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb")
     public void performQueueSendWithTimestampBasedSelectors()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberJMSTimestamp");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE, "jmsSelectorSubscriberJMSTimestamp");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setSelectors("JMSTimestamp > " + Long
                 .toString(System.currentTimeMillis() + 1000L));
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberJMSTimestamp");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE, "jmsSelectorSubscriberJMSTimestamp");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setRunningDelay(300L);  // Setting publishing delay
 
@@ -221,19 +227,22 @@ public class SelectorsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb")
     public void performQueueReceiverCustomPropertyBasedSelectors()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomProperty");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE, "jmsSelectorSubscriberCustomProperty");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setSelectors("location = 'wso2.trace'");
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration initialPublisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomProperty");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE, "jmsSelectorSubscriberCustomProperty");
         AndesJMSPublisherClientConfiguration secondaryPublisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomProperty");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE, "jmsSelectorSubscriberCustomProperty");
 
         // Creating clients
         AndesClient consumerClient = new AndesClient(consumerConfig, true);
@@ -289,19 +298,25 @@ public class SelectorsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb")
     public void performQueueReceiverCustomPropertyAndJMSTypeBasedSelectors()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomPropertyAndJMSType");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE,
+                                                        "jmsSelectorSubscriberCustomPropertyAndJMSType");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setSelectors("location = 'wso2.trace' AND JMSType='myMessage'");
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration initialPublisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomPropertyAndJMSType");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE,
+                                                         "jmsSelectorSubscriberCustomPropertyAndJMSType");
         AndesJMSPublisherClientConfiguration secondaryPublisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomPropertyAndJMSType");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE,
+                                                         "jmsSelectorSubscriberCustomPropertyAndJMSType");
 
         // Creating clients
         AndesClient consumerClient = new AndesClient(consumerConfig, true);
@@ -358,20 +373,26 @@ public class SelectorsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb")
     public void performQueueReceiverCustomPropertyOrJMSTypeBasedSelectors()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomPropertyOrJMSType");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE,
+                                                        "jmsSelectorSubscriberCustomPropertyOrJMSType");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setSelectors("location = 'wso2.palmGrove' OR JMSType='myMessage'");
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration initialPublisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomPropertyOrJMSType");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE,
+                                                         "jmsSelectorSubscriberCustomPropertyOrJMSType");
 
         AndesJMSPublisherClientConfiguration secondaryPublisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "jmsSelectorSubscriberCustomPropertyOrJMSType");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE,
+                                                         "jmsSelectorSubscriberCustomPropertyOrJMSType");
 
         // Creating clients
         AndesClient consumerClient = new AndesClient(consumerConfig, true);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SingleTopicPublishSubscribeTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SingleTopicPublishSubscribeTestCase.java
@@ -77,15 +77,18 @@ public class SingleTopicPublishSubscribeTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "topic"})
     public void performSingleTopicPublishSubscribeTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "hasitha");
-        consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT + 10); // To check if more than expected messages are received
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "hasitha");
+        // To check if more than expected messages are received
+        consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT + 10);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "hasitha");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "hasitha");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TemporaryTopicSubscriptionVerificationTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TemporaryTopicSubscriptionVerificationTestCase.java
@@ -57,20 +57,22 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
             description = "Single topic subscriber subscribe-close-re-subscribe test case")
     public void performSingleTopicSubscribeCloseResubscribeTest()
             throws AndesClientConfigurationException, NamingException, JMSException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         long sendCount = 1000L;
         long expectedCount = 200L;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration initialConsumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "singleSubscribeAndCloseTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.TOPIC, "singleSubscribeAndCloseTopic");
         initialConsumerConfig.setMaximumMessagesToReceived(expectedCount);
         initialConsumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "singleSubscribeAndCloseTopic");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.TOPIC, "singleSubscribeAndCloseTopic");
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
 
@@ -87,7 +89,8 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
 
         // Creating a second consumer client configuration
         AndesJMSConsumerClientConfiguration secondaryConsumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "singleSubscribeAndCloseTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.TOPIC, "singleSubscribeAndCloseTopic");
         secondaryConsumerConfig.setMaximumMessagesToReceived(1L);
 
         // Creating a seconds publisher client configuration
@@ -125,7 +128,7 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
     public void performMultipleTopicSubscribeCloseResubscribeTest()
             throws ExecutionException, AndesClientConfigurationException, NamingException,
                    JMSException,
-                   IOException, AndesClientException {
+                   IOException, AndesClientException, XPathExpressionException {
 
         long sendCount = 1000L;
         long expectedCountByClient1 = 1000L;
@@ -135,13 +138,15 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration initialConsumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
         initialConsumerConfig.setMaximumMessagesToReceived(expectedCountByClient1);
         initialConsumerConfig.setPrintsPerMessageCount(expectedCountByClient1 / 10L);
         initialConsumerConfig.setRunningDelay(100L); // Setting a delay in consuming each message.
 
         AndesJMSConsumerClientConfiguration secondaryConsumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
         secondaryConsumerConfig.setMaximumMessagesToReceived(expectedCountByClient2);
         secondaryConsumerConfig.setPrintsPerMessageCount(expectedCountByClient2 / 10L);
         secondaryConsumerConfig
@@ -149,7 +154,8 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
 
@@ -207,7 +213,8 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
             // Re-subscribe and see if messages are coming
             // Creating a  consumer client configuration
             AndesJMSConsumerClientConfiguration newConsumerConfig =
-                    new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
+                    new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                            ExchangeType.TOPIC, "multiSubscribeAndCloseTopic");
             newConsumerConfig.setMaximumMessagesToReceived(1L);
 
             // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantCreateQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantCreateQueueTestCase.java
@@ -80,18 +80,19 @@ public class TenantCreateQueueTestCase extends MBIntegrationBaseTest {
                                                                AndesClientConfigurationException,
                                                                JMSException,
                                                                NamingException,
-                                                               AndesClientException {
+                                                               AndesClientException,
+                                                               XPathExpressionException {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration("tenant1user1!testtenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "tenant1user1!testtenant1.com",
                                         "tenant1user1", ExchangeType.QUEUE, "testtenant1.com/www");
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT);
         consumerConfig.setPrintsPerMessageCount(EXPECTED_COUNT / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration("tenant1user1!testtenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "tenant1user1!testtenant1.com",
                                          "tenant1user1", ExchangeType.QUEUE, "testtenant1.com/www");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT / 10L);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantDeadLetterChannelTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantDeadLetterChannelTestCase.java
@@ -182,7 +182,7 @@ public class TenantDeadLetterChannelTestCase extends MBIntegrationBaseTest {
 
         // Create a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration("dlctenantuser1!dlctenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "dlctenantuser1!dlctenant1.com",
                                                         "dlctenantuser1", ExchangeType.QUEUE,
                                                         destinationName);
         // Add manual client acknowledgement in configuration
@@ -200,7 +200,7 @@ public class TenantDeadLetterChannelTestCase extends MBIntegrationBaseTest {
 
         // Create a publisher client configuration
         AndesJMSPublisherClientConfiguration tenantPublisherConfig =
-                new AndesJMSPublisherClientConfiguration("dlctenantuser1!dlctenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "dlctenantuser1!dlctenant1.com",
                                                          "dlctenantuser1", ExchangeType.QUEUE,
                                                          destinationName);
         tenantPublisherConfig.setNumberOfMessagesToSend(sendMessageCount);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicMessageSequentialAndDuplicateTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicMessageSequentialAndDuplicateTestCase.java
@@ -73,16 +73,21 @@ public class TopicMessageSequentialAndDuplicateTestCase extends MBIntegrationBas
     @Test(groups = {"wso2.mb", "topic"})
     public void performTopicMessageSequentialAndDuplicateTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "singleTopicSequentialAndDuplicate");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.TOPIC, "singleTopicSequentialAndDuplicate");
         consumerConfig.setMaximumMessagesToReceived(SEND_COUNT);
         consumerConfig.setPrintsPerMessageCount(SEND_COUNT/10L);
-        consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES); // file path to write received messages
+        // file path to write received messages
+        consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "singleTopicSequentialAndDuplicate");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.TOPIC, "singleTopicSequentialAndDuplicate");
         publisherConfig.setPrintsPerMessageCount(SEND_COUNT/10L);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicTestCase.java
@@ -67,19 +67,19 @@ public class TopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Single topic send-receive test case")
     public void performSingleTopicSendReceiveTestCase()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
         long sendCount = 1000L;
         long expectedCount = 1000L;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "singleTopic");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "singleTopic");
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "singleTopic");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "singleTopic");
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
 
@@ -121,44 +121,44 @@ public class TopicTestCase extends MBIntegrationBaseTest {
     public void performMultipleTenantTopicSendReceiveTestCase()
             throws AndesClientConfigurationException, CloneNotSupportedException, JMSException,
                    NamingException,
-                   IOException, AndesClientException {
+                   IOException, AndesClientException, XPathExpressionException {
         long sendCount = 100L;
         long expectedCount = 100L;
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration adminConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("admin", "admin", ExchangeType.TOPIC,
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "admin", "admin", ExchangeType.TOPIC,
                                                                                     "commontopic");
         adminConsumerConfig.setMaximumMessagesToReceived(expectedCount);
         adminConsumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         AndesJMSConsumerClientConfiguration tenant1ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("tenant1user1!testtenant1.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "tenant1user1!testtenant1.com",
                                 "tenant1user1", ExchangeType.TOPIC, "testtenant1.com/commontopic");
         tenant1ConsumerConfig.setMaximumMessagesToReceived(expectedCount);
         tenant1ConsumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         AndesJMSConsumerClientConfiguration tenant2ConsumerConfig =
-                new AndesJMSConsumerClientConfiguration("tenant2user1!testtenant2.com",
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), "tenant2user1!testtenant2.com",
                                 "tenant2user1", ExchangeType.TOPIC, "testtenant2.com/commontopic");
         tenant2ConsumerConfig.setMaximumMessagesToReceived(expectedCount);
         tenant2ConsumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration adminPublisherConfig =
-                new AndesJMSPublisherClientConfiguration("admin", "admin", ExchangeType.TOPIC,
-                                                                                    "commontopic");
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "admin", "admin",
+                                                         ExchangeType.TOPIC, "commontopic");
         adminPublisherConfig.setNumberOfMessagesToSend(sendCount);
         adminPublisherConfig.setPrintsPerMessageCount(sendCount / 10L);
 
         AndesJMSPublisherClientConfiguration tenant1PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("tenant1user1!testtenant1.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "tenant1user1!testtenant1.com",
                                  "tenant1user1", ExchangeType.TOPIC, "testtenant1.com/commontopic");
         tenant1PublisherConfig.setNumberOfMessagesToSend(sendCount);
         tenant1PublisherConfig.setPrintsPerMessageCount(sendCount / 10L);
 
         AndesJMSPublisherClientConfiguration tenant2PublisherConfig =
-                new AndesJMSPublisherClientConfiguration("tenant2user1!testtenant2.com",
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), "tenant2user1!testtenant2.com",
                                  "tenant2user1", ExchangeType.TOPIC, "testtenant2.com/commontopic");
         tenant2PublisherConfig.setNumberOfMessagesToSend(sendCount);
         tenant2PublisherConfig.setPrintsPerMessageCount(sendCount / 10L);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicUserAuthorizationTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicUserAuthorizationTestCase.java
@@ -517,14 +517,14 @@ public class TopicUserAuthorizationTestCase extends MBIntegrationBaseTest {
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration
                 consumerConfig =
-                new AndesJMSConsumerClientConfiguration(
+                new AndesJMSConsumerClientConfiguration( getAMQPPort(),
                                 contextUser.getUserNameWithoutDomain(), contextUser.getPassword(),
                                 ExchangeType.TOPIC, destinationName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(
+                new AndesJMSPublisherClientConfiguration( getAMQPPort(),
                         contextUser.getUserNameWithoutDomain(), contextUser.getPassword(),
                         ExchangeType.TOPIC, destinationName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TransactedAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TransactedAcknowledgementsTestCase.java
@@ -80,10 +80,12 @@ public class TransactedAcknowledgementsTestCase extends MBIntegrationBaseTest {
     @Test(groups = "wso2.mb", description = "Single queue send-receive test case with transactions")
     public void transactedAcknowledgements()
             throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-                   AndesClientException {
+                   AndesClientException, XPathExpressionException {
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "transactedAckTestQueue");
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(),
+                                                        ExchangeType.QUEUE, "transactedAckTestQueue");
         consumerConfig.setMaximumMessagesToReceived(100L);
         consumerConfig.setRunningDelay(100L);   // Setting a delay publishing each message
         consumerConfig.setRollbackAfterEachMessageCount(10);   // Roll back session after given message count
@@ -92,7 +94,9 @@ public class TransactedAcknowledgementsTestCase extends MBIntegrationBaseTest {
         consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES); // Write received messages to file
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "transactedAckTestQueue");
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(),
+                                                         ExchangeType.QUEUE, "transactedAckTestQueue");
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TransactionalPublishingTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TransactionalPublishingTestCase.java
@@ -81,19 +81,23 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "queue", "transaction" }, description = "Send message and check whether message is received, " +
             "and commit and check whether message is received")
     public void enqueueAndCheckCommitAndCheckTestCase() throws IOException, JMSException,
-            AndesClientException, NamingException, AndesClientConfigurationException, InterruptedException {
+                                                               AndesClientException,
+                                                               NamingException,
+                                                               AndesClientConfigurationException,
+                                                               InterruptedException,
+                                                               XPathExpressionException {
 
         int expectedCount = 1;
         int expectedBeforeCommit = 0;
         String queueName = "Transactional-enqueueAndCheckCommitAndCheckTestCase";
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setTransactionalSession(true);
         // Creating clients
         AndesClient consumerClient1 = new AndesClient(consumerConfig, true);
@@ -142,8 +146,10 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
      * @throws InterruptedException
      */
     @Test(groups = {"wso2.mb", "queue", "transaction" }, description = "Test for rollback functionality")
-    public void enqueueAndRollbackEnqueueAndCommitTestCase() throws AndesClientConfigurationException,
-            IOException, JMSException, AndesClientException, NamingException, InterruptedException {
+    public void enqueueAndRollbackEnqueueAndCommitTestCase()
+            throws AndesClientConfigurationException,
+                   IOException, JMSException, AndesClientException, NamingException,
+                   InterruptedException, XPathExpressionException {
 
         int expectedCount = 1;
         int expectedBeforeCommit = 0;
@@ -152,13 +158,13 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         consumerConfig
                 .setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES); // writing received messages.
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setTransactionalSession(true);
 
         // Creating clients
@@ -220,8 +226,10 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
      * @throws InterruptedException
      */
     @Test(groups = {"wso2.mb", "queue", "transaction" }, description = "Test transactions with multiple publishers")
-    public void multiplePublisherEnqueueAndCheckCommitAndCheckTestCase() throws AndesClientConfigurationException,
-            IOException, JMSException, AndesClientException, NamingException, InterruptedException {
+    public void multiplePublisherEnqueueAndCheckCommitAndCheckTestCase()
+            throws AndesClientConfigurationException,
+                   IOException, JMSException, AndesClientException, NamingException,
+                   InterruptedException, XPathExpressionException {
 
         int expectedCount = 1;
         int expectedBeforeCommit = 0;
@@ -230,20 +238,20 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, queueName1);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName1);
         consumerConfig1.setMaximumMessagesToReceived(expectedCount);
 
         AndesJMSConsumerClientConfiguration consumerConfig2 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, queueName2);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName2);
         consumerConfig2.setMaximumMessagesToReceived(expectedCount);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig1 =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName1);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName1);
         publisherConfig1.setTransactionalSession(true);
 
         AndesJMSPublisherClientConfiguration publisherConfig2 =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName2);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName2);
         publisherConfig2.setTransactionalSession(true);
 
         // Creating clients
@@ -323,8 +331,10 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "queue", "transaction" },
             description = "Test rollback functionality with multiple publishers")
-    public void multiplePublisherEnqueueAndRollbackEnqueueAndCommitTestCase() throws AndesClientConfigurationException,
-            IOException, JMSException, AndesClientException, NamingException, InterruptedException {
+    public void multiplePublisherEnqueueAndRollbackEnqueueAndCommitTestCase()
+            throws AndesClientConfigurationException,
+                   IOException, JMSException, AndesClientException, NamingException,
+                   InterruptedException, XPathExpressionException {
 
         int expectedCountAfterPub1Commit = 1;
         int expectedCountAfterPub2Commit = 2;
@@ -337,18 +347,18 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(waitForMessages);
         consumerConfig.
                 setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES); // writing received messages.
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig1 =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         publisherConfig1.setTransactionalSession(true);
 
         AndesJMSPublisherClientConfiguration publisherConfig2 =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         publisherConfig2.setTransactionalSession(true);
 
         // Creating clients
@@ -435,18 +445,20 @@ public class TransactionalPublishingTestCase extends MBIntegrationBaseTest {
             description = "Test the commit batch size limit check functionality",
             expectedExceptions = JMSException.class)
     public void exceedCommitBatchSizeTest() throws IOException, JMSException, AndesClientException,
-            NamingException, AndesClientConfigurationException {
+                                                   NamingException,
+                                                   AndesClientConfigurationException,
+                                                   XPathExpressionException {
 
         String queueName = "Transactional-exceedCommitBatchSizeTest";
         int messageSize = 1024 * 1024;
         int messageCount = 20;
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setTransactionalSession(true);
 
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, queueName);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(messageCount);
 
         // Creating clients

--- a/modules/integration/tests-integration/tests-amqp/src/test/resources/automation.xml
+++ b/modules/integration/tests-integration/tests-amqp/src/test/resources/automation.xml
@@ -270,8 +270,10 @@
                     <host type="default">localhost</host>
                 </hosts>
                 <ports>
-                    <port type="http">9763</port>
-                    <port type="https">9443</port>
+                    <port type="http">11063</port>
+                    <port type="https">10743</port>
+                    <port type="amqp">6972</port>
+                    <port type="sslamqp">9972</port>
                 </ports>
                 <properties>
 
@@ -287,7 +289,7 @@
             <extentionClasses>
 	<class>
 		<name>org.wso2.carbon.automation.extensions.servers.carbonserver.CarbonServerExtension</name>
-		<!--<parameter name="-DportOffset" value="0" />-->
+		<parameter name="-DportOffset" value="1300" />
 		<!--<parameter name="cmdArg" value="debug 5005" />-->
 	</class>
 	<class>

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSecurityTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSecurityTestCase.java
@@ -94,7 +94,7 @@ public class BasicSecurityTestCase extends MBIntegrationBaseTest {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
 
         MQTTClientConnectionConfiguration configuration =
-                                                          mqttClientEngine.getDefaultConfigurations();
+                               mqttClientEngine.getConfigurations(automationContext);
         
         String invalidUserName = "invalidUserName";        
         Tenant currentTenant = automationContext.getContextTenant();
@@ -131,7 +131,7 @@ public class BasicSecurityTestCase extends MBIntegrationBaseTest {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
         
         MQTTClientConnectionConfiguration configuration =
-                mqttClientEngine.getDefaultConfigurations();
+                mqttClientEngine.getConfigurations(automationContext);
         
         Tenant tenant = automationContext.getContextTenant();
         topic = tenant.getDomain() + "/" + topic;

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSendReceiveTestCase.java
@@ -30,6 +30,7 @@ import org.wso2.mb.integration.common.clients.QualityOfService;
 import org.wso2.mb.integration.common.clients.ClientMode;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
+import javax.xml.xpath.XPathExpressionException;
 import java.util.List;
 
 /**
@@ -56,7 +57,7 @@ public class BasicSendReceiveTestCase extends MBIntegrationBaseTest {
      * @throws MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt message send receive test case")
-    public void performBasicSendReceiveTestCase() throws MqttException {
+    public void performBasicSendReceiveTestCase() throws MqttException, XPathExpressionException {
         String topic = "topic";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
@@ -65,11 +66,11 @@ public class BasicSendReceiveTestCase extends MBIntegrationBaseTest {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(topic, QualityOfService.LEAST_ONCE, noOfSubscribers, saveMessages,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishers,
-                noOfMessages, ClientMode.BLOCKING);
+                noOfMessages, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 
@@ -88,7 +89,8 @@ public class BasicSendReceiveTestCase extends MBIntegrationBaseTest {
      * @throws MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt message send receive test case")
-    public void performBasicSendReceiveMultipleMessagesTestCase() throws MqttException {
+    public void performBasicSendReceiveMultipleMessagesTestCase()
+            throws MqttException, XPathExpressionException {
         String topic = "topic";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
@@ -97,11 +99,11 @@ public class BasicSendReceiveTestCase extends MBIntegrationBaseTest {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(topic, QualityOfService.LEAST_ONCE, noOfSubscribers, saveMessages,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishers,
-                noOfMessages, ClientMode.BLOCKING);
+                noOfMessages, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/CleanSessionTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/CleanSessionTestCase.java
@@ -32,6 +32,8 @@ import org.wso2.mb.integration.common.clients.QualityOfService;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 import org.wso2.mb.integration.tests.mqtt.DataProvider.QualityOfServiceDataProvider;
 
+import javax.xml.xpath.XPathExpressionException;
+
 /**
  * Verify MQTT clean session option by sending messages with clean session = false
  * and disconnecting the subscriber.
@@ -55,7 +57,8 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, dataProvider = "QualityOfServiceDataProvider",
             dataProviderClass = QualityOfServiceDataProvider.class)
-    public void performCleanSessionTestCase(QualityOfService qualityOfService) throws MqttException {
+    public void performCleanSessionTestCase(QualityOfService qualityOfService)
+            throws MqttException, XPathExpressionException {
         int noOfMessagesPerQos = 1;
         int noOfPublishersPerQos = 1;
         int expectedCount = noOfMessagesPerQos * 2; // Only qos 1 and 2 messages are expected
@@ -68,7 +71,7 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
         String topic = "CleanSessionTestTopic";
 
-        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getDefaultConfigurations();
+        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         configuration.setCleanSession(false);
 
         //create the subscribers
@@ -84,15 +87,18 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
 
         // Publish qos 0 message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.MOST_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING,
+                automationContext);
 
         // Publish qos 1 message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.LEAST_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING,
+                automationContext);
 
         // Publish qos 2 message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.EXACTLY_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING,
+                automationContext);
 
 
         // Re connect the subscriber and subscribe to the same topic
@@ -117,7 +123,8 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, dataProvider = "QualityOfServiceDataProvider",
             dataProviderClass = QualityOfServiceDataProvider.class)
-    public void performCleanSessionWithUnSubscriptionTestCase(QualityOfService qualityOfService) throws MqttException {
+    public void performCleanSessionWithUnSubscriptionTestCase(QualityOfService qualityOfService)
+            throws MqttException, XPathExpressionException {
         int noOfMessagesPerQos = 1;
         int noOfPublishersPerQos = 1;
         // Only qos 1 and 2 messages are expected, always we should not expect to receive
@@ -127,7 +134,7 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
         String topic = "CleanSessionTestTopic";
 
-        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getDefaultConfigurations();
+        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         configuration.setCleanSession(false);
 
         //create the subscribers
@@ -146,15 +153,18 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
 
         // Publish qos 0 message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.MOST_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING,
+                automationContext);
 
         // Publish qos 1 message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.LEAST_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING,
+                automationContext);
 
         // Publish qos 2 message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.EXACTLY_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishersPerQos, noOfMessagesPerQos, ClientMode.BLOCKING,
+                automationContext);
 
 
         // Re connect the subscriber and subscribe to the same topic

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/LongTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/LongTopicTestCase.java
@@ -30,6 +30,7 @@ import org.wso2.mb.integration.common.clients.QualityOfService;
 import org.wso2.mb.integration.common.clients.ClientMode;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
+import javax.xml.xpath.XPathExpressionException;
 import java.util.List;
 
 /**
@@ -51,18 +52,18 @@ public class LongTopicTestCase extends MBIntegrationBaseTest {
      * Send message and receive for a long topic hierarchy.
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Send message and receive for a long topic hierarchy")
-    public void performLongTopicTestCase() throws MqttException {
+    public void performLongTopicTestCase() throws MqttException, XPathExpressionException {
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
 
         String longTopic = "1/2/3/this_is_a_long_topic_that_needs_to/work/4/5/6/7/8";
 
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(longTopic, QualityOfService.LEAST_ONCE, 1, true,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.createPublisherConnection(longTopic, QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, 1, 1,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/QOSTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/QOSTestCase.java
@@ -31,6 +31,7 @@ import org.wso2.mb.integration.common.clients.ClientMode;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 import org.wso2.mb.integration.tests.mqtt.DataProvider.QualityOfServiceDataProvider;
 
+import javax.xml.xpath.XPathExpressionException;
 import java.util.List;
 
 /**
@@ -59,7 +60,8 @@ public class QOSTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Send message and receive in QOS 0",
             dataProvider = "QualityOfServiceDataProvider", dataProviderClass = QualityOfServiceDataProvider.class)
-    public void performQOS0TestCase(QualityOfService qualityOfService) throws MqttException {
+    public void performQOS0TestCase(QualityOfService qualityOfService)
+            throws MqttException, XPathExpressionException {
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;
@@ -67,10 +69,10 @@ public class QOSTestCase extends MBIntegrationBaseTest {
 
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(topicName, qualityOfService, noOfSubscribers, true,
-                ClientMode.ASYNC);
+                ClientMode.ASYNC, automationContext);
 
         mqttClientEngine.createPublisherConnection(topicName, qualityOfService, MQTTConstants.TEMPLATE_PAYLOAD,
-                noOfPublishers, noOfMessages, ClientMode.ASYNC);
+                noOfPublishers, noOfMessages, ClientMode.ASYNC, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/RetainTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/RetainTopicTestCase.java
@@ -62,7 +62,8 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
      * @throws org.eclipse.paho.client.mqttv3.MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt retain message send receive test case")
-    public void performSendReceiveRetainTopicTestCase() throws MqttException {
+    public void performSendReceiveRetainTopicTestCase()
+            throws MqttException, XPathExpressionException {
         String topic = "topic";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
@@ -72,12 +73,12 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
 
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
 
-        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getDefaultConfigurations();
+        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         configuration.setRetain(retained);
 
         //create the subscriber to receive retain topic message
         mqttClientEngine.createSubscriberConnection(topic, QualityOfService.MOST_ONCE, noOfSubscribers,
-                                                    saveMessages, ClientMode.BLOCKING);
+                                                    saveMessages, ClientMode.BLOCKING, automationContext);
 
         // create publisher to publish retain topic message
         mqttClientEngine.createPublisherConnection(topic, QualityOfService.MOST_ONCE,
@@ -108,7 +109,8 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
      * @throws org.eclipse.paho.client.mqttv3.MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt retain message send receive test case")
-    public void performSendReceiveRetainTopicForLateSubscriberTestCase() throws MqttException {
+    public void performSendReceiveRetainTopicForLateSubscriberTestCase()
+            throws MqttException, XPathExpressionException {
         String topic = "topic1";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
@@ -118,7 +120,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
 
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
 
-        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getDefaultConfigurations();
+        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         configuration.setRetain(retained);
 
         //First, create publisher and publish retain topic message
@@ -129,7 +131,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
 
         //Finally,create the subscriber to receive retain topic message
         mqttClientEngine.createSubscriberConnection(topic, QualityOfService.MOST_ONCE, noOfSubscribers,
-                                                    saveMessages, ClientMode.BLOCKING);
+                                                    saveMessages, ClientMode.BLOCKING, automationContext);
 
         // wait until all messages received by subscriber and shut down clients.
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
@@ -166,7 +168,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
      * @throws org.eclipse.paho.client.mqttv3.MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Remove MQTT retain test case")
-    public void performRemoveRetainTopicTestCase() throws MqttException {
+    public void performRemoveRetainTopicTestCase() throws MqttException, XPathExpressionException {
         String topic = "topic2";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
@@ -176,7 +178,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
 
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
 
-        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getDefaultConfigurations();
+        MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         // Set retain flag into configurations.
         configuration.setRetain(retained);
 
@@ -188,7 +190,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
 
         //Create the subscriber to receive retain topic message
         mqttClientEngine.createSubscriberConnection(topic, QualityOfService.MOST_ONCE, noOfSubscribers,
-                                                    saveMessages, ClientMode.BLOCKING);
+                                                    saveMessages, ClientMode.BLOCKING, automationContext);
 
 
         // wait until all messages received by subscriber.
@@ -222,7 +224,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
 
         //Create the new subscriber to receive retain topic message.
         mqttClientEngine1.createSubscriberConnection(topic, QualityOfService.MOST_ONCE, noOfSubscribers,
-                                                    saveMessages, ClientMode.BLOCKING);
+                                                    saveMessages, ClientMode.BLOCKING, automationContext);
 
         // wait until messages received by subscriber.
         mqttClientEngine1.waitUntilExpectedNumberOfMessagesReceived(0,20000L);

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/WildcardTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/WildcardTestCase.java
@@ -29,6 +29,8 @@ import org.wso2.mb.integration.common.clients.MQTTConstants;
 import org.wso2.mb.integration.common.clients.QualityOfService;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
+import javax.xml.xpath.XPathExpressionException;
+
 /**
  * Test different combinations of MQTT wildcards.
  *
@@ -66,7 +68,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
      * @throws MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Test multi level wildcard")
-    public void performMultiLevelWildcardTestCase() throws MqttException {
+    public void performMultiLevelWildcardTestCase() throws MqttException, XPathExpressionException {
         int noOfTopLevelSubscribers = 1;
         int noOfMidLevelSubscribers = 1;
 
@@ -76,18 +78,18 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
 
         // Receive all the messages
         mqttClientEngine.createSubscriberConnection(multiLevelWildCard, QualityOfService.LEAST_ONCE,
-                noOfTopLevelSubscribers, false, ClientMode.BLOCKING);
+                noOfTopLevelSubscribers, false, ClientMode.BLOCKING, automationContext);
 
         // Receive messages published to 'multi/level' and all it's sub levels
         mqttClientEngine.createSubscriberConnection("multi/level/" + multiLevelWildCard, QualityOfService.LEAST_ONCE,
-                noOfMidLevelSubscribers, false, ClientMode.BLOCKING);
+                noOfMidLevelSubscribers, false, ClientMode.BLOCKING, automationContext);
 
         // Creating Publishers
 
         // Publish to 'multi/level/wild/card'
         mqttClientEngine.createPublisherConnection("multi/level/wild/card", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceived();
         int receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -101,7 +103,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
         // Publish to 'multi'
         mqttClientEngine.createPublisherConnection("multi", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
         receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -127,7 +129,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
      * @throws MqttException
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Test single level wildcard")
-    public void performSingleLevelWildcardTest() throws MqttException {
+    public void performSingleLevelWildcardTest() throws MqttException, XPathExpressionException {
         int noOfTopLevelOnlySubscribers = 1;
         int noOfMidLevelOnlySubscribers = 1;
         int noOfLeafLevelOnlySubscribers = 1;
@@ -138,23 +140,23 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
 
         // Receive all the messages published to top nodes only
         mqttClientEngine.createSubscriberConnection(singleLevelWildCard, QualityOfService.LEAST_ONCE,
-                noOfTopLevelOnlySubscribers, false, ClientMode.BLOCKING);
+                noOfTopLevelOnlySubscribers, false, ClientMode.BLOCKING, automationContext);
 
         // Receive messages published to 'single/<any>' and all it's sub levels
         mqttClientEngine.createSubscriberConnection("single/" + singleLevelWildCard,
                 QualityOfService.LEAST_ONCE,
-                noOfMidLevelOnlySubscribers, false, ClientMode.BLOCKING);
+                noOfMidLevelOnlySubscribers, false, ClientMode.BLOCKING, automationContext);
 
         // Receive messages published to 'single/level/<any>' and all it's sub levels
         mqttClientEngine.createSubscriberConnection("single/level/" + singleLevelWildCard, QualityOfService.LEAST_ONCE,
-                noOfLeafLevelOnlySubscribers, false, ClientMode.BLOCKING);
+                noOfLeafLevelOnlySubscribers, false, ClientMode.BLOCKING, automationContext);
 
         // Creating Publishers
 
         // Publish to 'single'
         mqttClientEngine.createPublisherConnection("single", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceived();
         int receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -166,7 +168,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
         // Publish to 'single/level'
         mqttClientEngine.createPublisherConnection("single/level", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceived();
         receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -179,7 +181,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
         // Publish to 'single/level/wildcard'
         mqttClientEngine.createPublisherConnection("single/level/wildcard", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
         receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -204,7 +206,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Test single level and multi level wildcards in conjunction",
             enabled = false)
-    public void performMixWildcardTestCase() throws MqttException { // Disabled due to MQTT Client not supporting
+    public void performMixWildcardTestCase() throws MqttException, XPathExpressionException { // Disabled due to MQTT Client not supporting
         int noOfAllLevelSubscribers = 1;
         int noOfMidAnySubscribers = 1;
         int noOfStartWithAnySubscribers = 1;
@@ -216,26 +218,29 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
 
         // Receive all the messages published - '+/#'
         mqttClientEngine.createSubscriberConnection(singleLevelWildCard + "/" + multiLevelWildCard,
-                QualityOfService.LEAST_ONCE, noOfAllLevelSubscribers, false, ClientMode.BLOCKING);
+                QualityOfService.LEAST_ONCE, noOfAllLevelSubscribers, false, ClientMode.BLOCKING,
+                automationContext);
 
         // Receive all the messages published to 'mixed/<any>/wild' and all it's sub topics
         mqttClientEngine.createSubscriberConnection("mixed/" + singleLevelWildCard + "/wild/" + multiLevelWildCard,
-                QualityOfService.LEAST_ONCE, noOfMidAnySubscribers, false, ClientMode.BLOCKING);
+                QualityOfService.LEAST_ONCE, noOfMidAnySubscribers, false, ClientMode.BLOCKING, automationContext);
 
         // Receive all the messages published to '<any>/level' and all it's sub topics
         mqttClientEngine.createSubscriberConnection(singleLevelWildCard + "/level/" + multiLevelWildCard,
-                QualityOfService.LEAST_ONCE, noOfStartWithAnySubscribers, false, ClientMode.BLOCKING);
+                QualityOfService.LEAST_ONCE, noOfStartWithAnySubscribers, false, ClientMode.BLOCKING,
+                automationContext);
 
         // Receive all the messages published to sub trees of 'mixed/level' but not 'mixed/level'
         mqttClientEngine.createSubscriberConnection("mixed/level" + singleLevelWildCard + "/" + multiLevelWildCard,
-                QualityOfService.LEAST_ONCE, noOfAdjacentWildcardSubscribers, false, ClientMode.BLOCKING);
+                QualityOfService.LEAST_ONCE, noOfAdjacentWildcardSubscribers, false, ClientMode.BLOCKING,
+                automationContext );
 
         // Creating Publishers
 
         // Publish to 'mixed'
         mqttClientEngine.createPublisherConnection("mixed", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceived();
         int receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -248,7 +253,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
         // Publish to 'mixed/level'
         mqttClientEngine.createPublisherConnection("mixed/level", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceived();
         receivedMessageCount = mqttClientEngine.getReceivedMessageCount();
@@ -262,7 +267,7 @@ public class WildcardTestCase extends MBIntegrationBaseTest {
         // Publish to 'mixed/level/wild/card'
         mqttClientEngine.createPublisherConnection("mixed/level/wild/card", QualityOfService.LEAST_ONCE,
                 MQTTConstants.TEMPLATE_PAYLOAD, noOfPublisherThreads,
-                noOfMessagesPerPublisher, ClientMode.BLOCKING);
+                noOfMessagesPerPublisher, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
         receivedMessageCount = mqttClientEngine.getReceivedMessageCount();

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/load/MultiThreadedMQTTTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/load/MultiThreadedMQTTTestCase.java
@@ -30,6 +30,8 @@ import org.wso2.mb.integration.common.clients.ClientMode;
 import org.wso2.mb.integration.common.clients.QualityOfService;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 
+import javax.xml.xpath.XPathExpressionException;
+
 /**
  * Send and receive via multiple publisher and multiple subscribers.
  */
@@ -52,7 +54,7 @@ public class MultiThreadedMQTTTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Send a large amount of messages and receive via multiple MQTT " +
             "clients")
-    public void performMultiThreadedMQTTTestCase() throws MqttException {
+    public void performMultiThreadedMQTTTestCase() throws MqttException, XPathExpressionException {
         String topicName = "MultiThreadedTopic";
         int sendCount = 100000;
         int noOfPublishers = 10;
@@ -62,10 +64,11 @@ public class MultiThreadedMQTTTestCase extends MBIntegrationBaseTest {
 
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(topicName, QualityOfService.MOST_ONCE, noOfSubscribers, false,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.createPublisherConnection(topicName, QualityOfService.MOST_ONCE,
-                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishers, sendCount / noOfPublishers, ClientMode.BLOCKING);
+                MQTTConstants.TEMPLATE_PAYLOAD, noOfPublishers, sendCount / noOfPublishers, ClientMode.BLOCKING,
+                automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/load/OneMBMessageTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/load/OneMBMessageTestCase.java
@@ -34,6 +34,7 @@ import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 import org.wso2.mb.integration.tests.mqtt.DataProvider.QualityOfServiceDataProvider;
 
+import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -63,7 +64,8 @@ public class OneMBMessageTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Send and receive large Message of 1 MB",
             dataProvider = "QualityOfServiceDataProvider", dataProviderClass = QualityOfServiceDataProvider.class)
-    public void performOneMBLoadTestCase(QualityOfService qualityOfService) throws MqttException, IOException {
+    public void performOneMBLoadTestCase(QualityOfService qualityOfService)
+            throws MqttException, IOException, XPathExpressionException {
         int sendCount = 10;
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
@@ -79,10 +81,10 @@ public class OneMBMessageTestCase extends MBIntegrationBaseTest {
 
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(topicName, qualityOfService, noOfSubscribers, false,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.createPublisherConnection(topicName, qualityOfService, oneMBBytes, noOfPublishers, sendCount,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/load/QOSLoadTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/load/QOSLoadTestCase.java
@@ -31,6 +31,8 @@ import org.wso2.mb.integration.common.clients.QualityOfService;
 import org.wso2.mb.integration.common.utils.backend.MBIntegrationBaseTest;
 import org.wso2.mb.integration.tests.mqtt.DataProvider.QualityOfServiceDataProvider;
 
+import javax.xml.xpath.XPathExpressionException;
+
 /**
  * Send a large number of message via multiple MQTT clients for each QOS level.
  */
@@ -55,7 +57,8 @@ public class QOSLoadTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Send and receive large number of message via QOS 0",
             dataProvider = "QualityOfServiceDataProvider", dataProviderClass = QualityOfServiceDataProvider.class)
-    public void performQOS0LoadTestCase(QualityOfService qualityOfService) throws MqttException {
+    public void performQOS0LoadTestCase(QualityOfService qualityOfService)
+            throws MqttException, XPathExpressionException {
         int sendCount = 100000;
         int noOfSubscribers = 10;
         int noOfPublishers = 10;
@@ -65,10 +68,10 @@ public class QOSLoadTestCase extends MBIntegrationBaseTest {
 
         //create the subscribers
         mqttClientEngine.createSubscriberConnection(topicName, qualityOfService, noOfSubscribers, false,
-                ClientMode.BLOCKING);
+                ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.createPublisherConnection(topicName, qualityOfService, MQTTConstants.TEMPLATE_PAYLOAD,
-                noOfPublishers, sendCount / noOfPublishers, ClientMode.BLOCKING);
+                noOfPublishers, sendCount / noOfPublishers, ClientMode.BLOCKING, automationContext);
 
         mqttClientEngine.waitUntilAllMessageReceivedAndShutdownClients();
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/resources/automation.xml
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/resources/automation.xml
@@ -203,8 +203,10 @@
                     <host type="default">localhost</host>
                 </hosts>
                 <ports>
-                    <port type="http">9763</port>
-                    <port type="https">9443</port>
+                    <port type="http">11063</port>
+                    <port type="https">10743</port>
+                    <port type="mqtt">3183</port>
+                    <port type="sslmqtt">10183</port>
                 </ports>
                 <properties>
 
@@ -220,7 +222,7 @@
             <extentionClasses>
 	<class>
 		<name>org.wso2.carbon.automation.extensions.servers.carbonserver.CarbonServerExtension</name>
-		<!--<parameter name="-DportOffset" value="0" />-->
+		<parameter name="-DportOffset" value="1300" />
 		<!--<parameter name="cmdArg" value="debug 5005" />-->
 	</class>
 	<class>

--- a/modules/integration/tests-integration/tests-server/src/test/java/org/wso2/mb/integration/tests/server/mgt/MetricsTestCase.java
+++ b/modules/integration/tests-integration/tests-server/src/test/java/org/wso2/mb/integration/tests/server/mgt/MetricsTestCase.java
@@ -112,13 +112,13 @@ public class MetricsTestCase extends MBIntegrationBaseTest {
 
 		// Creating a consumer client configuration
 		AndesJMSConsumerClientConfiguration consumerConfig =
-				new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "singleQueue");
+				new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueue");
 		consumerConfig.setMaximumMessagesToReceived(msgCount * 2);
 		consumerConfig.setPrintsPerMessageCount(msgCount / 10L);
 
 		// Creating a publisher client configuration
 		AndesJMSPublisherClientConfiguration publisherConfig =
-				new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "singleQueue");
+				new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueue");
 		publisherConfig.setNumberOfMessagesToSend(msgCount);
 		publisherConfig.setPrintsPerMessageCount(msgCount / 10L);
 
@@ -190,13 +190,13 @@ public class MetricsTestCase extends MBIntegrationBaseTest {
 
 		// Creating a consumer client configuration
 		AndesJMSConsumerClientConfiguration consumerConfig =
-				new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "singleTopic");
+				new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "singleTopic");
 		consumerConfig.setMaximumMessagesToReceived(msgCount * 2);
 		consumerConfig.setPrintsPerMessageCount(msgCount / 10L);
 
 		// Creating a publisher client configuration
 		AndesJMSPublisherClientConfiguration publisherConfig =
-				new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, "singleTopic");
+				new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "singleTopic");
 		publisherConfig.setNumberOfMessagesToSend(msgCount);
 		publisherConfig.setPrintsPerMessageCount(msgCount / 10L);
 
@@ -256,19 +256,20 @@ public class MetricsTestCase extends MBIntegrationBaseTest {
 	 */
 	@Test(groups = "wso2.mb", description = "Metrics report test case")
 	public void performMetricsReportTestCase()
-			throws AndesClientConfigurationException, JMSException, NamingException, IOException,
-			       AndesClientException, InterruptedException, MalformedObjectNameException {
+            throws AndesClientConfigurationException, JMSException, NamingException, IOException,
+                   AndesClientException, InterruptedException, MalformedObjectNameException,
+                   XPathExpressionException {
 		long msgCount = 1000L;
 
 		// Creating a consumer client configuration
 		AndesJMSConsumerClientConfiguration consumerConfig =
-				new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, "singleQueue");
+				new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueue");
 		consumerConfig.setMaximumMessagesToReceived(msgCount * 2);
 		consumerConfig.setPrintsPerMessageCount(msgCount / 10L);
 
 		// Creating a publisher client configuration
 		AndesJMSPublisherClientConfiguration publisherConfig =
-				new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, "singleQueue");
+				new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, "singleQueue");
 		publisherConfig.setNumberOfMessagesToSend(msgCount);
 		publisherConfig.setPrintsPerMessageCount(msgCount / 10L);
 
@@ -443,9 +444,15 @@ public class MetricsTestCase extends MBIntegrationBaseTest {
 	 * @throws IOException
 	 * @throws MalformedObjectNameException
 	 */
-	private void invokeJMXReportOperation() throws IOException, MalformedObjectNameException{
+	private void invokeJMXReportOperation()
+            throws IOException, MalformedObjectNameException, XPathExpressionException {
+
+        int JMXServicePort = getJMXServerPort();
+        int RMIRegistryPort = getRMIRegistryPort();
+
 		JMXServiceURL url =
-				new JMXServiceURL("service:jmx:rmi://localhost:11111/jndi/rmi://localhost:9999/jmxrmi");
+				new JMXServiceURL("service:jmx:rmi://localhost:" + JMXServicePort +
+                                  "/jndi/rmi://localhost:" + RMIRegistryPort + "/jmxrmi");
 		Map<String, String[]> env = new HashMap<>();
 		String[] credentials = {"admin", "admin"};
 		env.put(JMXConnector.CREDENTIALS, credentials);

--- a/modules/integration/tests-integration/tests-server/src/test/resources/automation.xml
+++ b/modules/integration/tests-integration/tests-server/src/test/resources/automation.xml
@@ -172,8 +172,11 @@
                     <host type="default">localhost</host>
                 </hosts>
                 <ports>
-                    <port type="http">9763</port>
-                    <port type="https">9443</port>
+                    <port type="http">11063</port>
+                    <port type="https">10743</port>
+                    <port type="amqp">6972</port>
+                    <port type="jmxserver">12411</port>
+                    <port type="rmiregistry">11299</port>
                 </ports>
                 <properties>
 
@@ -189,7 +192,7 @@
             <extentionClasses>
 	<class>
 		<name>org.wso2.carbon.automation.extensions.servers.carbonserver.CarbonServerExtension</name>
-		<!--<parameter name="-DportOffset" value="0" />-->
+		<parameter name="-DportOffset" value="1300" />
 		<!--<parameter name="cmdArg" value="debug 5005" />-->
 	</class>
 	<class>

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/dlc/DLCDurableTopicTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/dlc/DLCDurableTopicTestCase.java
@@ -128,7 +128,7 @@ public class DLCDurableTopicTestCase extends MBIntegrationUiBaseTest {
     @BeforeMethod(dependsOnMethods = {"cleanDeadLetterChannel"})
     public void addDurableTopicMessagesToDLC()
             throws AndesClientConfigurationException, NamingException,
-                   JMSException, IOException, AndesClientException {
+                   JMSException, IOException, AndesClientException, XPathExpressionException {
         // Get current "AndesAckWaitTimeOut" system property.
         defaultAndesAckWaitTimeOut = System.getProperty(AndesClientConstants.ANDES_ACK_WAIT_TIMEOUT_PROPERTY);
 
@@ -137,7 +137,7 @@ public class DLCDurableTopicTestCase extends MBIntegrationUiBaseTest {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig = new
-                AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, DLC_TEST_DURABLE_TOPIC);
+                AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, DLC_TEST_DURABLE_TOPIC);
         // Amount of message to receive
         consumerConfig.setDurable(true, DLC_TEST_DURABLE_TOPIC);
         consumerConfig.setSubscriptionID("durable-topic-sub-1");
@@ -146,7 +146,7 @@ public class DLCDurableTopicTestCase extends MBIntegrationUiBaseTest {
         consumerConfig.setAcknowledgeAfterEachMessageCount(EXPECTED_COUNT + 200L);
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.TOPIC, DLC_TEST_DURABLE_TOPIC);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, DLC_TEST_DURABLE_TOPIC);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         consumerClient = new AndesClient(consumerConfig, true);

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/dlc/DLCQueueTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/dlc/DLCQueueTestCase.java
@@ -175,14 +175,14 @@ public class DLCQueueTestCase extends MBIntegrationUiBaseTest {
 
         // Creating a initial JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.QUEUE, DLC_TEST_QUEUE);
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, DLC_TEST_QUEUE);
         // Amount of message to receive
         consumerConfig.setMaximumMessagesToReceived(EXPECTED_COUNT + 200L);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.CLIENT_ACKNOWLEDGE);
         consumerConfig.setAcknowledgeAfterEachMessageCount(EXPECTED_COUNT + 210L);
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(ExchangeType.QUEUE, DLC_TEST_QUEUE);
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, DLC_TEST_QUEUE);
         publisherConfig.setNumberOfMessagesToSend(SEND_COUNT);
 
         AndesClient consumerClient = new AndesClient(consumerConfig, true);

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/messagecontent/ViewMessageContentTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/messagecontent/ViewMessageContentTestCase.java
@@ -126,8 +126,8 @@ public class ViewMessageContentTestCase extends MBIntegrationUiBaseTest {
         long sendCount = 1;
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(
-                                                                                ExchangeType.QUEUE, TEST_QUEUE_NAME);
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, TEST_QUEUE_NAME);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setReadMessagesFromFilePath(MESSAGE_CONTENT_INPUT_FILE_PATH);
 

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/queues/QueueDeleteTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/queues/QueueDeleteTestCase.java
@@ -116,8 +116,8 @@ public class QueueDeleteTestCase extends MBIntegrationUiBaseTest {
         Assert.assertEquals(queueAddPage.addQueue(queueName), true);
 
         // Creating a publisher client configuration
-        AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(ExchangeType
-                .QUEUE, queueName);
+        AndesJMSPublisherClientConfiguration publisherConfig =
+                new AndesJMSPublisherClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(1000);
         publisherConfig.setPrintsPerMessageCount(100L);
 

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/queues/QueueDeleteWithSubscriber.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/queues/QueueDeleteWithSubscriber.java
@@ -88,8 +88,8 @@ public class QueueDeleteWithSubscriber extends MBIntegrationUiBaseTest {
         Assert.assertEquals(queueAddPage.addQueue(queueName), true);
 
         // Creating a consumer client configuration
-        AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(
-                                                                                    ExchangeType.QUEUE, queueName);
+        AndesJMSConsumerClientConfiguration consumerConfig =
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.QUEUE, queueName);
 
         // Creating a subscriber and listens.
         AndesClient consumerClient = new AndesClient(consumerConfig, true);

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/topic/SharedDurableSubscriptionTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/topic/SharedDurableSubscriptionTestCase.java
@@ -88,7 +88,7 @@ public class SharedDurableSubscriptionTestCase extends MBIntegrationUiBaseTest {
 
         // Creating a JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "sharedDurableTopic1");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "sharedDurableTopic1");
         consumerConfig.setDurable(true, "client-id-shared-1");
 
         // Creating clients
@@ -174,11 +174,11 @@ public class SharedDurableSubscriptionTestCase extends MBIntegrationUiBaseTest {
 
         // Creating a JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "sharedDurableTopic4");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "sharedDurableTopic4");
         consumerConfig1.setDurable(true, "client-id-shared-4");
 
         AndesJMSConsumerClientConfiguration consumerConfig2 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "sharedDurableTopic4");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "sharedDurableTopic4");
         consumerConfig2.setDurable(true, "client-id-shared-5");
 
         // Creating clients
@@ -263,11 +263,11 @@ public class SharedDurableSubscriptionTestCase extends MBIntegrationUiBaseTest {
 
         // Creating a JMS consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "sharedDurableTopic2");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "sharedDurableTopic2");
         consumerConfig1.setDurable(true, "client-id-shared-2");
 
         AndesJMSConsumerClientConfiguration consumerConfig2 =
-                new AndesJMSConsumerClientConfiguration(ExchangeType.TOPIC, "sharedDurableTopic3");
+                new AndesJMSConsumerClientConfiguration(getAMQPPort(), ExchangeType.TOPIC, "sharedDurableTopic3");
         consumerConfig2.setDurable(true, "client-id-shared-3");
 
         // Creating clients

--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/topic/TopicTenantTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/topic/TopicTenantTestCase.java
@@ -95,7 +95,8 @@ public class TopicTenantTestCase extends MBIntegrationUiBaseTest {
 
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
 
-        MQTTClientConnectionConfiguration mqttClientConnectionConfiguration = mqttClientEngine.getDefaultConfigurations();
+        MQTTClientConnectionConfiguration mqttClientConnectionConfiguration =
+                mqttClientEngine.getConfigurations(mbServer);
         mqttClientConnectionConfiguration.setBrokerUserName("bob!home.com");
         mqttClientConnectionConfiguration.setBrokerPassword("marleyandme");
 

--- a/modules/integration/tests-ui-integration/src/test/resources/automation.xml
+++ b/modules/integration/tests-ui-integration/src/test/resources/automation.xml
@@ -181,8 +181,12 @@
                     <host type="default">localhost</host>
                 </hosts>
                 <ports>
-                    <port type="http">9763</port>
-                    <port type="https">9443</port>
+                    <port type="http">11063</port>
+                    <port type="https">10743</port>
+                    <port type="amqp">6972</port>
+                    <port type="sslamqp">9972</port>
+                    <port type="mqtt">3183</port>
+                    <port type="sslmqtt">10183</port>
                 </ports>
                 <properties>
 
@@ -198,7 +202,7 @@
             <extentionClasses>
                 <class>
                     <name>org.wso2.carbon.automation.extensions.servers.carbonserver.CarbonServerExtension</name>
-                    <!--<parameter name="-DportOffset" value="0" />-->
+                    <parameter name="-DportOffset" value="1300" />
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>


### PR DESCRIPTION
Add required changes to easily change ports according to port offset of the carbon server.
with this change ports added in automation.xml will override deafult ports in test clients.
Carbon port offset has set to 1300.

Following ports has been changed according to the port offset.

Carbon server
1. http -        11063
2. https -      10743
3. jmx server  - 12411
4. rmi registry - 11299

AMQP
5. amqp -      6972
6. amqp ssl - 9972

MQTT
7. mqtt -       3183
8. mqtt ssl - 10183

JIRA - https://wso2.org/jira/browse/MB-1219