### PR TITLE
[MB-1268] Implemented message count retrieval for all queues

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/clients/AndesAdminClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/clients/AndesAdminClient.java
@@ -21,8 +21,6 @@ package org.wso2.mb.integration.common.clients.operations.clients;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.client.Options;
 import org.apache.axis2.client.ServiceClient;
-import org.apache.commons.lang3.StringUtils;
-import org.wso2.andes.kernel.AndesConstants;
 import org.wso2.carbon.andes.stub.AndesAdminServiceBrokerManagerAdminException;
 import org.wso2.carbon.andes.stub.AndesAdminServiceStub;
 import org.wso2.carbon.andes.stub.admin.types.Message;
@@ -121,18 +119,7 @@ public class AndesAdminClient {
      */
     public Queue getQueueByName(String name)
             throws RemoteException, AndesAdminServiceBrokerManagerAdminException {
-        Queue[] queues = stub.getAllQueues();
-
-        if (queues != null && queues.length > 0) {
-            for (Queue queue : queues) {
-                if (queue.getQueueName().equalsIgnoreCase(name)) {
-                    return queue;
-
-                }
-            }
-        }
-
-        return null;
+        return stub.getQueueByName(name);
     }
 
     /**
@@ -172,21 +159,7 @@ public class AndesAdminClient {
      */
     public Queue getDlcQueue() throws AndesAdminServiceBrokerManagerAdminException,
             java.rmi.RemoteException {
-
-        Queue[] queueList = stub.getAllQueues();
-        Queue dlcQueue = null;
-
-        if (null != queueList) {
-            for (Queue queue : queueList) {
-                String nameOfQueue = queue.getQueueName();
-                if (StringUtils.isNotBlank(nameOfQueue) && nameOfQueue.contains(
-                        AndesConstants.DEAD_LETTER_QUEUE_SUFFIX)) {
-                    dlcQueue = queue;
-                    break;
-                }
-            }
-        }
-        return dlcQueue;
+        return stub.getDLCQueue();
     }
 
 }


### PR DESCRIPTION
Addresses the changes made to the core by wso2/andes#386 due to https://wso2.org/jira/browse/MB-1268

Please merge https://github.com/wso2/andes/pull/386 and https://github.com/wso2/carbon-business-messaging/pull/171 along with this.