### PR TITLE
Parallel test run

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/utils/AndesClientUtils.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/utils/AndesClientUtils.java
@@ -145,6 +145,17 @@ public class AndesClientUtils {
     }
 
     /**
+     * Shutdown the client gracefully without waiting.
+     *
+     * @param client The client to shutdown
+     * @throws JMSException
+     */
+    public static void shutdownClient(AndesClient client) throws JMSException {
+        client.stopClient();
+        flushPrintWriters();
+    }
+
+    /**
      * Sleeps for a certain time.
      *
      * @param milliseconds Sleep time in milliseconds.

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/AutoAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/AutoAcknowledgementsTestCase.java
@@ -59,7 +59,6 @@ public class AutoAcknowledgementsTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(1000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/ClientAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/ClientAcknowledgementsTestCase.java
@@ -61,7 +61,6 @@ public class ClientAcknowledgementsTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -118,7 +117,7 @@ public class ClientAcknowledgementsTestCase extends MBIntegrationBaseTest {
                 .getReceivedMessageCount();
 
         Assert.assertEquals(publisherClient
-                                    .getSentMessageCount(), SEND_COUNT, "Expected message count not received.");
+                                    .getSentMessageCount(), SEND_COUNT, "Expected message count not sent.");
         Assert.assertEquals(totalMessagesReceived, EXPECTED_COUNT, "Expected message count not received.");
     }
 }

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DifferentSubscriptionsWithDurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DifferentSubscriptionsWithDurableTopicTestCase.java
@@ -50,7 +50,6 @@ public class DifferentSubscriptionsWithDurableTopicTestCase extends MBIntegratio
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -144,21 +143,21 @@ public class DifferentSubscriptionsWithDurableTopicTestCase extends MBIntegratio
         AndesClientUtils.waitForMessagesAndShutdown(durableTopicConsumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
         Assert.assertEquals(durableTopicConsumerClient1.getReceivedMessageCount(), EXPECTED_COUNT, "Message receive error from durable subscriber 1");
 
-        AndesClientUtils.waitForMessagesAndShutdown(durableTopicConsumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(durableTopicConsumerClient2);
         Assert.assertEquals(durableTopicConsumerClient2.getReceivedMessageCount(), EXPECTED_COUNT, "Message receive error from durable subscriber 2");
 
-        AndesClientUtils.waitForMessagesAndShutdown(normalTopicConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(normalTopicConsumerClient);
         Assert.assertEquals(normalTopicConsumerClient.getReceivedMessageCount(), EXPECTED_COUNT, "Message receive error from normal topic subscriber");
 
-        AndesClientUtils.waitForMessagesAndShutdown(normalHierarchicalTopicConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(normalHierarchicalTopicConsumerClient);
         Assert.assertEquals(normalHierarchicalTopicConsumerClient.getReceivedMessageCount(), EXPECTED_COUNT,
                             "Message receive error from normal hierarchical topic subscriber");
 
-        AndesClientUtils.waitForMessagesAndShutdown(durableHierarchicalTopicConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(durableHierarchicalTopicConsumerClient);
         Assert.assertEquals(durableHierarchicalTopicConsumerClient.getReceivedMessageCount(), EXPECTED_COUNT,
                             "Message receive error from durable hierarchical topic subscriber");
 
-        AndesClientUtils.waitForMessagesAndShutdown(queueConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(queueConsumerClient);
         Assert.assertEquals(queueConsumerClient.getReceivedMessageCount(), 0L,
                             "Message received from queue subscriber. This should not happen");
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DuplicatesOkAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DuplicatesOkAcknowledgementsTestCase.java
@@ -61,7 +61,6 @@ public class DuplicatesOkAcknowledgementsTestCase extends MBIntegrationBaseTest 
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(1000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableMultipleTopicSubscriberTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableMultipleTopicSubscriberTestCase.java
@@ -56,7 +56,6 @@ public class DurableMultipleTopicSubscriberTestCase extends MBIntegrationBaseTes
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -112,8 +111,7 @@ public class DurableMultipleTopicSubscriberTestCase extends MBIntegrationBaseTes
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
 
         // Evaluating
         Assert.assertEquals(publisherClient

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicSubscriptionWithSameClientIdTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicSubscriptionWithSameClientIdTestCase.java
@@ -20,9 +20,11 @@ package org.wso2.mb.integration.tests.amqp.functional;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.engine.frameworkutils.FrameworkPathUtil;
+import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
 import org.wso2.carbon.integration.common.utils.mgt.ServerConfigurationManager;
 import org.wso2.mb.integration.common.clients.AndesClient;
 import org.wso2.mb.integration.common.clients.configurations.AndesJMSConsumerClientConfiguration;
@@ -116,10 +118,8 @@ public class DurableTopicSubscriptionWithSameClientIdTestCase extends MBIntegrat
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient3, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
+        AndesClientUtils.shutdownClient(consumerClient3);
 
         // Evaluating
         Assert.assertEquals(publisherClient
@@ -196,17 +196,11 @@ public class DurableTopicSubscriptionWithSameClientIdTestCase extends MBIntegrat
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient3, AndesClientConstants.DEFAULT_RUN_TIME);
-
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient4, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient5, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClient6, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
+        AndesClientUtils.shutdownClient(consumerClient3);
+        AndesClientUtils.shutdownClient(consumerClient4);
+        AndesClientUtils.shutdownClient(consumerClient5);
+        AndesClientUtils.shutdownClient(consumerClient6);
 
         // Evaluating
         Assert.assertEquals(publisherClient1
@@ -225,5 +219,16 @@ public class DurableTopicSubscriptionWithSameClientIdTestCase extends MBIntegrat
                         .getReceivedMessageCount() + consumerClient6.getReceivedMessageCount();
         Assert.assertEquals(totalReceivingMessageCount, SEND_COUNT_8, "Message receive count not equal to sent message " +
                                                                     "count for 'durableTopicSameClientIDTopic2'.");
+    }
+
+    /**
+     * Restore to the previous configurations when the shared subscription test is complete.
+     *
+     * @throws IOException
+     * @throws AutomationUtilException
+     */
+    @AfterClass
+    public void tearDown() throws IOException, AutomationUtilException {
+        super.serverManager.restoreToLastConfiguration(true);
     }
 }

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicTestCase.java
@@ -61,7 +61,6 @@ public class DurableTopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/HierarchicalTopicsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/HierarchicalTopicsTestCase.java
@@ -60,7 +60,6 @@ public class HierarchicalTopicsTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionMessageReceiveOrderTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionMessageReceiveOrderTestCase.java
@@ -67,7 +67,6 @@ public class JMSSubscriberTransactionMessageReceiveOrderTestCase extends MBInteg
     @BeforeClass
     public void prepare() throws Exception {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
 

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionsSessionCommitRollbackTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/JMSSubscriberTransactionsSessionCommitRollbackTestCase.java
@@ -62,7 +62,6 @@ public class JMSSubscriberTransactionsSessionCommitRollbackTestCase extends MBIn
     @BeforeClass
     public void prepare() throws Exception {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MessageContentTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MessageContentTestCase.java
@@ -68,7 +68,6 @@ public class MessageContentTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedDurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedDurableTopicTestCase.java
@@ -74,7 +74,6 @@ public class MixedDurableTopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedQueueTestCase.java
@@ -49,7 +49,6 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -180,7 +179,7 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
         publisherClientWithExpiration.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(initialConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(secondaryConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(secondaryConsumerClient);
 
         // Evaluating
         Assert.assertEquals(publisherClientWithoutExpiration.getSentMessageCount(), sendCountWithoutExpiration, "Message send failed for publisher without expiration.");

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MixedTopicTestCase.java
@@ -76,7 +76,6 @@ public class MixedTopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantDurableTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantDurableTopicTestCase.java
@@ -84,7 +84,6 @@ public class MultiTenantDurableTopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException, RemoteException, UserAdminUserAdminException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
 
         // Logging into user management as admin and adding a new role to give permission for publishing/subscribe
         userManagementClient = new UserManagementClient(backendURL, "admin@topictenant1.com",
@@ -240,8 +239,7 @@ public class MultiTenantDurableTopicTestCase extends MBIntegrationBaseTest {
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(tenant1ConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(tenant2ConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(tenant2ConsumerClient);
 
         // Evaluating
         Assert.assertEquals(tenant1PublisherClient

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantQueueTestCase.java
@@ -81,7 +81,6 @@ public class MultiTenantQueueTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException, RemoteException, UserAdminUserAdminException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
 
 
         // Logging into user management as admin and adding a new role to give permission for publishing/subscribe
@@ -231,8 +230,7 @@ public class MultiTenantQueueTestCase extends MBIntegrationBaseTest {
 
         AndesClientUtils.waitForMessagesAndShutdown(tenant1ConsumerClient,
                                                             AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(tenant2ConsumerClient,
-                                                            AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(tenant2ConsumerClient);
 
         // Evaluating
         Assert.assertEquals(tenant1PublisherClient.getSentMessageCount(), sendMessageCount1,

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultiTenantTopicTestCase.java
@@ -60,7 +60,6 @@ public class MultiTenantTopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -119,8 +118,7 @@ public class MultiTenantTopicTestCase extends MBIntegrationBaseTest {
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(adminConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(tenant1ConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(tenant1ConsumerClient);
 
         // Evaluating
         Assert.assertEquals(tenant2PublisherClient
@@ -198,8 +196,7 @@ public class MultiTenantTopicTestCase extends MBIntegrationBaseTest {
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(tenant1ConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(tenant2ConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(tenant2ConsumerClient);
 
         // Evaluating
         Assert.assertEquals(tenant1PublisherClient

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleQueueSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleQueueSendReceiveTestCase.java
@@ -59,7 +59,6 @@ public class MultipleQueueSendReceiveTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -113,7 +112,7 @@ public class MultipleQueueSendReceiveTestCase extends MBIntegrationBaseTest {
         publisherClient2.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
 
         // Evaluating
         long sentMessageCount = publisherClient1.getSentMessageCount() + publisherClient2.getSentMessageCount();

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleTopicPublishSubscribeTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/MultipleTopicPublishSubscribeTestCase.java
@@ -58,7 +58,6 @@ public class MultipleTopicPublishSubscribeTestCase extends MBIntegrationBaseTest
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -115,7 +114,7 @@ public class MultipleTopicPublishSubscribeTestCase extends MBIntegrationBaseTest
         publisherClient2.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
 
         // Evaluating
         Assert.assertEquals(publisherClient1.getSentMessageCount(), SEND_COUNT_2000 * 2L, "Publisher publisherClient1 failed to publish messages");

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/PurgeMessagesTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/PurgeMessagesTestCase.java
@@ -74,7 +74,6 @@ public class PurgeMessagesTestCase extends MBIntegrationBaseTest {
     @BeforeClass()
     public void init() throws XPathExpressionException, MalformedURLException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -180,8 +179,8 @@ public class PurgeMessagesTestCase extends MBIntegrationBaseTest {
 
         //Receiving messages until message count gets stagnant and
         //Once done, stop client
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, 10000l);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, 10000l);
+        AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
 
         //Creating admin client
         AndesAdminClient admin = new AndesAdminClient(super.backendURL, sessionCookie);

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageRedeliveryWithAckTimeOutTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageRedeliveryWithAckTimeOutTestCase.java
@@ -61,7 +61,6 @@ public class QueueMessageRedeliveryWithAckTimeOutTestCase extends MBIntegrationB
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageSequentialAndDuplicateTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageSequentialAndDuplicateTestCase.java
@@ -54,7 +54,6 @@ public class QueueMessageSequentialAndDuplicateTestCase extends MBIntegrationBas
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueSubscriptionsBreakAndReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueSubscriptionsBreakAndReceiveTestCase.java
@@ -67,7 +67,6 @@ public class QueueSubscriptionsBreakAndReceiveTestCase extends MBIntegrationBase
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueTestCase.java
@@ -50,7 +50,6 @@ public class QueueTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -197,7 +196,7 @@ public class QueueTestCase extends MBIntegrationBaseTest {
 
         // Waiting for all messages
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
 
         // Evaluating
         long msgCountFromClient1 = consumerClient1.getReceivedMessageCount();

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SSLSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SSLSendReceiveTestCase.java
@@ -61,7 +61,6 @@ public class SSLSendReceiveTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SingleTopicPublishSubscribeTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/SingleTopicPublishSubscribeTestCase.java
@@ -60,7 +60,6 @@ public class SingleTopicPublishSubscribeTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         init(TestUserMode.SUPER_TENANT_ADMIN);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TemporaryTopicSubscriptionVerificationTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TemporaryTopicSubscriptionVerificationTestCase.java
@@ -38,7 +38,6 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -179,8 +178,7 @@ public class TemporaryTopicSubscriptionVerificationTestCase extends MBIntegratio
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(initialConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(secondaryConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(secondaryConsumerClient);
 
         // Evaluating
         Assert.assertEquals(publisherClient

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantCreateQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantCreateQueueTestCase.java
@@ -60,7 +60,6 @@ public class TenantCreateQueueTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantDeadLetterChannelTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TenantDeadLetterChannelTestCase.java
@@ -86,7 +86,6 @@ public class TenantDeadLetterChannelTestCase extends MBIntegrationBaseTest {
     public void init() throws XPathExpressionException, RemoteException,
                               UserAdminUserAdminException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
 
         // Get current "AndesAckWaitTimeOut" system property.
         defaultAndesAckWaitTimeOut = System.getProperty(AndesClientConstants.

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicMessageSequentialAndDuplicateTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicMessageSequentialAndDuplicateTestCase.java
@@ -55,7 +55,6 @@ public class TopicMessageSequentialAndDuplicateTestCase extends MBIntegrationBas
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicTestCase.java
@@ -50,7 +50,6 @@ public class TopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -186,10 +185,8 @@ public class TopicTestCase extends MBIntegrationBaseTest {
 
         AndesClientUtils.waitForMessagesAndShutdown(adminConsumerClient,
                                                             AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(tenant1ConsumerClient,
-                                                            AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(tenant2ConsumerClient,
-                                                            AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(tenant1ConsumerClient);
+        AndesClientUtils.shutdownClient(tenant2ConsumerClient);
 
         // Evaluating
         Assert.assertEquals(adminPublisherClient.getSentMessageCount(), sendCount, "Sending " +

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TransactedAcknowledgementsTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TransactedAcknowledgementsTestCase.java
@@ -61,7 +61,6 @@ public class TransactedAcknowledgementsTestCase extends MBIntegrationBaseTest {
     @BeforeClass
     public void prepare() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(1000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/ManySubscribersTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/ManySubscribersTestCase.java
@@ -70,7 +70,6 @@ public class ManySubscribersTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedMultipleQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedMultipleQueueTestCase.java
@@ -60,7 +60,6 @@ public class MultiThreadedMultipleQueueTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedMultipleQueueTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedMultipleQueueTopicTestCase.java
@@ -65,7 +65,6 @@ public class MultiThreadedMultipleQueueTopicTestCase extends MBIntegrationBaseTe
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedMultipleTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedMultipleTopicTestCase.java
@@ -60,7 +60,6 @@ public class MultiThreadedMultipleTopicTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedQueueTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedQueueTestCase.java
@@ -54,7 +54,6 @@ public class MultiThreadedQueueTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/MultiThreadedTopicTestCase.java
@@ -54,7 +54,6 @@ public class MultiThreadedTopicTestCase extends MBIntegrationBaseTest{
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueAckMixTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueAckMixTestCase.java
@@ -58,7 +58,6 @@ public class QueueAckMixTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -106,7 +105,7 @@ public class QueueAckMixTestCase extends MBIntegrationBaseTest {
         publisherClient.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerReturnedClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerReturnedClient);
 
         // Evaluation
         long totalReceivedMessageCount = consumerClient.getReceivedMessageCount() + consumerReturnedClient.getReceivedMessageCount();

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueAutoAckSubscriberCloseTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueAutoAckSubscriberCloseTestCase.java
@@ -59,7 +59,6 @@ public class QueueAutoAckSubscriberCloseTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**
@@ -103,7 +102,7 @@ public class QueueAutoAckSubscriberCloseTestCase extends MBIntegrationBaseTest {
         publisherClient.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClosingClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClosingClient);
 
         // Evaluating
         long totalReceivedMessageCount = consumerClient.getReceivedMessageCount() + consumerClosingClient.getReceivedMessageCount();

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueAutoAckTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueAutoAckTestCase.java
@@ -54,7 +54,6 @@ public class QueueAutoAckTestCase extends MBIntegrationBaseTest {
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueLargeMessageSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/QueueLargeMessageSendReceiveTestCase.java
@@ -54,7 +54,6 @@ public class QueueLargeMessageSendReceiveTestCase extends MBIntegrationBaseTest 
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/TopicLargeMessagePublishConsumeTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/load/TopicLargeMessagePublishConsumeTestCase.java
@@ -51,7 +51,6 @@ public class TopicLargeMessagePublishConsumeTestCase extends MBIntegrationBaseTe
     @BeforeClass(alwaysRun = true)
     public void init() throws XPathExpressionException {
         super.init(TestUserMode.SUPER_TENANT_USER);
-        AndesClientUtils.sleepForInterval(15000);
     }
 
     /**

--- a/modules/integration/tests-integration/tests-amqp/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-amqp/src/test/resources/testng.xml
@@ -20,11 +20,30 @@
 
 <suite name="transport-test-suite">
     <parameter name="useDefaultListeners" value="false"/>
-    <test name="tests-transports" preserve-order="true" parallel="false">
 
-        <!--<packages>-->
-        <!--<package name="org.wso2.mb.integration.tests.amqp.*"/>-->
-        <!--</packages>-->
+    <!-- These test run sequentially -->
+    <test name="tests-amqp-sequential" preserve-order="true" parallel="false">
+        <classes>
+             Test with server restarts and test with @BeforeMethod or @AfterMethod code are added here
+            <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicServerRestartTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.TopicUserAuthorizationTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.PurgeMessagesTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionWithSameClientIdTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.QueueUserAuthorizationTestCase"/>
+
+            <!-- This classes are added here since verification is done by writing to file and multiple subscribers
+                 are not supported -->
+            <class name="org.wso2.mb.integration.tests.amqp.functional.TransactedAcknowledgementsTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.JMSSubscriberTransactionMessageReceiveOrderTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.JMSSubscriberTransactionsSessionCommitRollbackTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.QueueMessageSequentialAndDuplicateTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.TopicMessageSequentialAndDuplicateTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.TransactionalPublishingTestCase"/>
+        </classes>
+    </test>
+
+    <!-- These tests run in parallel -->
+    <test name="tests-amqp-parallel" preserve-order="false" parallel="true" thread-count="10">
 
         <classes>
 
@@ -33,7 +52,6 @@
             <class name="org.wso2.mb.integration.tests.amqp.functional.AutoAcknowledgementsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.ClientAcknowledgementsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DuplicatesOkAcknowledgementsTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.JMSSubscriberTransactionsSessionCommitRollbackTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MessageContentTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MixedQueueTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultipleQueueSendReceiveTestCase"/>
@@ -41,25 +59,20 @@
             Its an intermittent failure. -->
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultiTenantQueueTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.QueueMessageRedeliveryWithAckTimeOutTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.QueueMessageSequentialAndDuplicateTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.QueueSubscriptionsBreakAndReceiveTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.QueueTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.QueueUserAuthorizationTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.SelectorsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.SSLSendReceiveTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TenantCreateQueueTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TenantDeleteQueueTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.InterTenantQueueTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.TransactedAcknowledgementsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TenantDeadLetterChannelTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.JMSSubscriberTransactionMessageReceiveOrderTestCase"/>
 
             <!-- Topic -->
 
             <class name="org.wso2.mb.integration.tests.amqp.functional.DifferentSubscriptionsWithDurableTopicTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableMultipleTopicSubscriberTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionWithSameClientIdTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.HierarchicalTopicsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MixedDurableTopicTestCase"/>
@@ -69,13 +82,7 @@
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultiTenantTopicTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.SingleTopicPublishSubscribeTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TemporaryTopicSubscriptionVerificationTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.TopicMessageSequentialAndDuplicateTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.TopicTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.TopicUserAuthorizationTestCase"/>
-
-            <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicServerRestartTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.TransactionalPublishingTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.PurgeMessagesTestCase"/>
 
             <!-- load test cases-->
 

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSecurityTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSecurityTestCase.java
@@ -88,7 +88,7 @@ public class BasicSecurityTestCase extends MBIntegrationBaseTest {
     @Test(groups = { "wso2.mb", "mqtt" }, description = "Try to connect to MB using a invalid user name and a password", 
             expectedExceptions = MqttException.class, expectedExceptionsMessageRegExp = ".*Bad user name or password.*")
     public void performInvalidUserCredentialsTestCase() throws MqttException, XPathExpressionException {
-        String topic = "topic";
+        String topic = "InvalidUserCredentialsTestCase:" + userMode.name();
         int inValidNumberOfMessages = 1; // we don't really expect to send
                                          // messages.
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
@@ -123,7 +123,7 @@ public class BasicSecurityTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt message send receive test case with non admin user, super tenant")
     public void performBasicSendReceiveTestCaseWithNonAdminCredentials() throws MqttException, XPathExpressionException {
-        String topic = "topic";
+        String topic = "BasicSendReceiveTestCaseWithNonAdminCredentials:" + userMode.name();
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSendReceiveTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/BasicSendReceiveTestCase.java
@@ -58,7 +58,7 @@ public class BasicSendReceiveTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt message send receive test case")
     public void performBasicSendReceiveTestCase() throws MqttException, XPathExpressionException {
-        String topic = "topic";
+        String topic = "BasicSendReceiveTestCase";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;
@@ -91,7 +91,7 @@ public class BasicSendReceiveTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt message send receive test case")
     public void performBasicSendReceiveMultipleMessagesTestCase()
             throws MqttException, XPathExpressionException {
-        String topic = "topic";
+        String topic = "BasicSendReceiveMultipleMessagesTestCase";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 100;

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/CleanSessionTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/CleanSessionTestCase.java
@@ -69,7 +69,7 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
         }
 
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
-        String topic = "CleanSessionTestTopic";
+        String topic = "CleanSessionTestCase" + qualityOfService.getValue();
 
         MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         configuration.setCleanSession(false);
@@ -132,7 +132,7 @@ public class CleanSessionTestCase extends MBIntegrationBaseTest {
         int expectedCount = 0;
 
         MQTTClientEngine mqttClientEngine = new MQTTClientEngine();
-        String topic = "CleanSessionTestTopic";
+        String topic = "CleanSessionWithUnSubscriptionTestCase" + qualityOfService.getValue();
 
         MQTTClientConnectionConfiguration configuration = mqttClientEngine.getConfigurations(automationContext);
         configuration.setCleanSession(false);

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/QOSTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/QOSTestCase.java
@@ -39,8 +39,6 @@ import java.util.List;
  */
 public class QOSTestCase extends MBIntegrationBaseTest {
 
-    private static final String topicName = "topic";
-
     /**
      * Initialize super class.
      *
@@ -62,6 +60,7 @@ public class QOSTestCase extends MBIntegrationBaseTest {
             dataProvider = "QualityOfServiceDataProvider", dataProviderClass = QualityOfServiceDataProvider.class)
     public void performQOS0TestCase(QualityOfService qualityOfService)
             throws MqttException, XPathExpressionException {
+        String topicName = "QOSTestCase" + qualityOfService.getValue();
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;

--- a/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/RetainTopicTestCase.java
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/java/org/wso2/mb/integration/tests/mqtt/functional/RetainTopicTestCase.java
@@ -64,7 +64,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt retain message send receive test case")
     public void performSendReceiveRetainTopicTestCase()
             throws MqttException, XPathExpressionException {
-        String topic = "topic";
+        String topic = "SendReceiveRetainTopicTestCase";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;
@@ -111,7 +111,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Single mqtt retain message send receive test case")
     public void performSendReceiveRetainTopicForLateSubscriberTestCase()
             throws MqttException, XPathExpressionException {
-        String topic = "topic1";
+        String topic = "SendReceiveRetainTopicForLateSubscriberTestCase";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;
@@ -169,7 +169,7 @@ public class RetainTopicTestCase extends MBIntegrationBaseTest {
      */
     @Test(groups = {"wso2.mb", "mqtt"}, description = "Remove MQTT retain test case")
     public void performRemoveRetainTopicTestCase() throws MqttException, XPathExpressionException {
-        String topic = "topic2";
+        String topic = "RemoveRetainTopicTestCase";
         int noOfSubscribers = 1;
         int noOfPublishers = 1;
         int noOfMessages = 1;

--- a/modules/integration/tests-integration/tests-mqtt/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-mqtt/src/test/resources/testng.xml
@@ -20,14 +20,22 @@
 
 <suite name="transport-test-suite">
     <parameter name="useDefaultListeners" value="false"/>
-    <test name="tests-transports-mqtt" preserve-order="true" parallel="false">
+
+    <!-- Test that needs to run individually -->
+    <test name="tests-transports-mqtt-sequential" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.mb.integration.tests.mqtt.functional.WildcardTestCase"/>
+        </classes>
+    </test>
+
+    <!-- Tests which can run in parallel -->
+    <test name="tests-transports-mqtt-parallel" preserve-order="false" parallel="methods" thread-count="10">
 
         <classes>
             <!-- functional test cases -->
             <class name="org.wso2.mb.integration.tests.mqtt.functional.BasicSendReceiveTestCase"/>
             <class name="org.wso2.mb.integration.tests.mqtt.functional.LongTopicTestCase"/>
             <class name="org.wso2.mb.integration.tests.mqtt.functional.QOSTestCase"/>
-            <class name="org.wso2.mb.integration.tests.mqtt.functional.WildcardTestCase"/>
             <class name="org.wso2.mb.integration.tests.mqtt.functional.BasicSecurityTestCase"/>
             <class name="org.wso2.mb.integration.tests.mqtt.functional.CleanSessionTestCase"/>
             <class name="org.wso2.mb.integration.tests.mqtt.functional.RetainTopicTestCase"/>

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MultipleSubscriberMultiplePublisherTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MultipleSubscriberMultiplePublisherTestCase.java
@@ -129,9 +129,9 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         publisherClient4.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient3, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient4, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
+        AndesClientUtils.shutdownClient(consumerClient3);
+        AndesClientUtils.shutdownClient(consumerClient4);
         // Wait until consumers are closed
         Thread.sleep(AndesClientConstants.DEFAULT_RUN_TIME);
 
@@ -245,9 +245,9 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         publisherClient4.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient3, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient4, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
+        AndesClientUtils.shutdownClient(consumerClient3);
+        AndesClientUtils.shutdownClient(consumerClient4);
 
         Assert.assertEquals(publisherClient1.getSentMessageCount(), sendCount, "Message sending failed by publisherClient1.");
         Assert.assertEquals(publisherClient2.getSentMessageCount(), sendCount, "Message sending failed by publisherClient2.");
@@ -377,9 +377,9 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         publisherClient4.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient2, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient3, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerClient4, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClient2);
+        AndesClientUtils.shutdownClient(consumerClient3);
+        AndesClientUtils.shutdownClient(consumerClient4);
 
         Assert.assertEquals(publisherClient1.getSentMessageCount(), sendCount, "Message sending failed by publisherClient1.");
         Assert.assertEquals(publisherClient2.getSentMessageCount(), sendCount, "Message sending failed by publisherClient2.");

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/QueueAckMixTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/QueueAckMixTestCase.java
@@ -144,7 +144,7 @@ public class QueueAckMixTestCase extends MBPlatformBaseTest {
         publisherClient.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(consumerReturnClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerReturnClient);
 
         log.info("Total Received Messages [" + consumerClient.getReceivedMessageCount() + "]");
 

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/QueueAutoAckSubscriberCloseTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/QueueAutoAckSubscriberCloseTestCase.java
@@ -151,8 +151,7 @@ public class QueueAutoAckSubscriberCloseTestCase extends MBPlatformBaseTest {
 
         AndesClientUtils
                 .waitForMessagesAndShutdown(consumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(consumerClosingClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(consumerClosingClient);
 
         log.info("Total Received Messages [" + consumerClient.getReceivedMessageCount() + "]");
 

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/MultipleSubscriberMultiplePublisherTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/MultipleSubscriberMultiplePublisherTopicTestCase.java
@@ -140,7 +140,7 @@ public class MultipleSubscriberMultiplePublisherTopicTestCase extends MBPlatform
         publisherClient.startClient();
 
         AndesClientUtils.waitForMessagesAndShutdown(initialConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils.waitForMessagesAndShutdown(secondaryConsumerClient, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(secondaryConsumerClient);
 
         // Evaluating
         Assert.assertEquals(publisherClient.getSentMessageCount(), sendCount, "Message sending failed.");

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/MultipleTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/topic/MultipleTopicTestCase.java
@@ -150,26 +150,16 @@ public class MultipleTopicTestCase extends MBPlatformBaseTest {
         sendingClient9.startClient();
         sendingClient10.startClient();
 
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient1, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient2, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient3, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient4, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient5, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient6, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient7, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient8, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient9, AndesClientConstants.DEFAULT_RUN_TIME);
-        AndesClientUtils
-                .waitForMessagesAndShutdown(receivingClient10, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.waitForMessagesAndShutdown(receivingClient1, AndesClientConstants.DEFAULT_RUN_TIME);
+        AndesClientUtils.shutdownClient(receivingClient2);
+        AndesClientUtils.shutdownClient(receivingClient3);
+        AndesClientUtils.shutdownClient(receivingClient4);
+        AndesClientUtils.shutdownClient(receivingClient5);
+        AndesClientUtils.shutdownClient(receivingClient6);
+        AndesClientUtils.shutdownClient(receivingClient7);
+        AndesClientUtils.shutdownClient(receivingClient8);
+        AndesClientUtils.shutdownClient(receivingClient9);
+        AndesClientUtils.shutdownClient(receivingClient10);
 
         // Evaluating
         Assert.assertEquals(sendingClient1


### PR DESCRIPTION
Reduce product mb build time by
- Allowing tests to run in parallel.
- Removing unwanted thread sleeps in the AMQP test suite.