### PR TITLE
multitenancy-4.4.4, registry-4.5.0 and commons-4.4.8 upgrade

### DIFF
--- a/modules/p2-profile/pom.xml
+++ b/modules/p2-profile/pom.xml
@@ -101,6 +101,9 @@
                                     org.wso2.carbon.registry:org.wso2.carbon.registry.core.feature:${carbon.registry.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
+                                    org.wso2.carbon.registry:org.wso2.carbon.registry.contentsearch.feature:${carbon.registry.version}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.registry:org.wso2.carbon.registry.ui.menu.feature:${carbon.registry.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
@@ -215,6 +218,10 @@
                                 <feature>
                                     <id>org.wso2.carbon.tryit.feature.group</id>
                                     <version>${carbon.commons.version}</version>
+                                </feature>
+                                <feature>
+                                    <id>org.wso2.carbon.registry.contentsearch.feature.group</id>
+                                    <version>${carbon.registry.version}</version>
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.registry.core.feature.group</id>

--- a/pom.xml
+++ b/pom.xml
@@ -433,11 +433,11 @@
         <orbit.version.rampart>1.6.1.wso2v10</orbit.version.rampart>
         <!--Apache Derby-->
         <version.wso2.derby>10.3.2.1wso2v1</version.wso2.derby>
-        <carbon.commons.version>4.4.7</carbon.commons.version>
+        <carbon.commons.version>4.4.8</carbon.commons.version>
         <carbon.identity.version>4.5.6</carbon.identity.version>
-        <carbon.registry.version>4.4.5</carbon.registry.version>
+        <carbon.registry.version>4.5.0</carbon.registry.version>
         <carbon.messaging.version>3.0.0-SNAPSHOT</carbon.messaging.version>
-        <carbon.multitenancy.version>4.4.3</carbon.multitenancy.version>
+        <carbon.multitenancy.version>4.4.4</carbon.multitenancy.version>
         <carbon.metrics.version>1.1.1</carbon.metrics.version>
         <carbon.kernel.version>4.4.2</carbon.kernel.version>
         <andes.version>3.0.0-SNAPSHOT</andes.version>


### PR DESCRIPTION
Upgraded multitenancy, registry and commons versions.

multitenancy-4.4.4 requires registry-4.5.0 and commons-4.4.8.