### PR TITLE
Introducing MQTT over Websocket transport and adding unit tests

### DIFF
--- a/carbon-mb/components/transports/mqtt/pom.xml
+++ b/carbon-mb/components/transports/mqtt/pom.xml
@@ -84,6 +84,45 @@
             <groupId>org.wso2.carbon.messaging</groupId>
             <artifactId>org.wso2.carbon.messaging</artifactId>
         </dependency>
+
+        <!-- Testing dependencies -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.ant</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-container-native</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.exam</groupId>
+            <artifactId>pax-exam-testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/carbon-mb/components/transports/mqtt/pom.xml
+++ b/carbon-mb/components/transports/mqtt/pom.xml
@@ -100,10 +100,6 @@
             <artifactId>org.jacoco.ant</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/config/MqttTransportConfiguration.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/config/MqttTransportConfiguration.java
@@ -42,6 +42,12 @@ public class MqttTransportConfiguration {
     @XmlElement(name = "mqttSSL")
     private MqttSecuredTransportProperties mqttSecuredTransportProperties;
 
+    /**
+     * Holds the websocket related properties
+     */
+    @XmlElement(name = "mqttWebsocket")
+    private MqttWebsocketTransportProperties mqttWebsocketTransportProperties;
+
 
     public MqttTransportProperties getMqttTransportProperties() {
         return mqttTransportProperties;
@@ -57,5 +63,13 @@ public class MqttTransportConfiguration {
 
     public void setMqttSecuredTransportProperties(MqttSecuredTransportProperties mqttSecuredTransportProperties) {
         this.mqttSecuredTransportProperties = mqttSecuredTransportProperties;
+    }
+
+    public MqttWebsocketTransportProperties getMqttWebsocketTransportProperties() {
+        return mqttWebsocketTransportProperties;
+    }
+
+    public void setMqttWebsocketTransportProperties(MqttWebsocketTransportProperties mqttWebsocketTransportProperties) {
+        this.mqttWebsocketTransportProperties = mqttWebsocketTransportProperties;
     }
 }

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/config/MqttWebsocketTransportProperties.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/config/MqttWebsocketTransportProperties.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.andes.transports.config;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+/**
+ * Defines MQTT websocket
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class MqttWebsocketTransportProperties extends MqttTransportProperties {
+    /**
+     * holds the port of the server
+     */
+    @XmlAttribute
+    private int port = 80;
+
+    /**
+     * holds the host name of the server
+     */
+    @XmlAttribute
+    private String host = "localhost";
+
+    /**
+     * number of acceptance threads
+     */
+    @XmlAttribute
+    private int acceptanceThreads = 0;
+
+    /**
+     * number of worker threads
+     */
+    @XmlAttribute
+    private int workerThreads = 0;
+
+    /**
+     * Defines the unique id for the transport
+     */
+    @XmlAttribute
+    private String id = "mqttWebSocket";
+
+    public MqttWebsocketTransportProperties() {
+    }
+
+    public MqttWebsocketTransportProperties(String host, int port, int acceptanceThreads, int workerThreads, String
+            id) {
+        this.host = host;
+        this.port = port;
+        this.acceptanceThreads = acceptanceThreads;
+        this.workerThreads = workerThreads;
+        this.id = id;
+    }
+
+    /**
+     * Holds the name of the protocol
+     */
+    private String protocol;
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public void setProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getAcceptanceThreads() {
+        return acceptanceThreads;
+    }
+
+    public void setAcceptanceThreads(int acceptanceThreads) {
+        this.acceptanceThreads = acceptanceThreads;
+    }
+
+    public int getWorkerThreads() {
+        return workerThreads;
+    }
+
+    public void setWorkerThreads(int workerThreads) {
+        this.workerThreads = workerThreads;
+    }
+
+    public void setHost(String host) {
+
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+}

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/etc/conf/mqtt-transports.yaml
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/etc/conf/mqtt-transports.yaml
@@ -21,6 +21,14 @@ mqttTransportProperties:
  acceptanceThreads: 0
  workerThreads: 0
  id: mqtt
+
+mqttWebsocketTransportProperties:
+  host: localhost
+  port: 9773
+  acceptanceThreads: 0
+  workerThreads: 0
+  id: mqttWebSocket
+
 mqttSecuredTransportProperties:
 
  host: localhost

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/MqttWebSocketServer.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/MqttWebSocketServer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.andes.transports.mqtt;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.MessageToMessageDecoder;
+import io.netty.handler.codec.MessageToMessageEncoder;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.timeout.IdleStateHandler;
+import org.wso2.carbon.andes.transports.mqtt.netty.handlers.IdleStateEventMqttHandler;
+import org.wso2.carbon.andes.transports.mqtt.netty.handlers.MqttMessagingHandler;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.decoders.MQTTDecoder;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.encoders.MQTTEncoder;
+import org.wso2.carbon.andes.transports.server.AbstractServer;
+
+import java.util.List;
+
+/**
+ * Initializes websockets over MQTT transport
+ */
+public class MqttWebSocketServer extends AbstractServer {
+
+    @Override
+    public void createPipeline(ChannelPipeline pipeline) {
+        //We define an additional pipeline to validate ssl certificates
+        // pipeline.addLast("mqttSSL", getSSLConnectionEngine());
+
+        //We would want to encode HTTP header portion of websockets
+        pipeline.addLast("httpResponseEncoder", new HttpResponseEncoder());
+
+        //We need to decode HTTP requests
+        pipeline.addLast("httpRequestDecoder", new HttpRequestDecoder());
+
+        pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
+
+        pipeline.addLast("WebsocketProtocolHandler", new WebSocketServerProtocolHandler("/mqtt", "mqttv3.1, mqttv3.1" +
+                ".1"));
+
+        pipeline.addLast("WebsocketToByteBufferDecoder", new WebSocketFrameToByteBufDecoder());
+
+        pipeline.addLast("ByteToWebsocketEncoder", new ByteBufToWebSocketFrameEncoder());
+
+        //Triggers when there's no activity for the channel (read/write) for DEFAULT_CONNECT_TIMEOUT
+        pipeline.addFirst("idleStateMQTTHandler", new IdleStateHandler(MqttConstants.READER_IDLE_TIME,
+                MqttConstants.WRITER_IDLE_TIME,
+                MqttConstants.DEFAULT_CONNECT_TIMEOUT));
+
+        //idleStateHandler would need to notify when its condition is fulfilled
+        //Following would trigger the event generated from idleStateHandler
+        //We need to also ensure this is triggered right after idle state handler
+        pipeline.addAfter("idleStateMQTTHandler", "idleStateMQTTEventHandler", new IdleStateEventMqttHandler());
+
+        //The MQTTDecoder extends ChannelInboundHandlerAdapter, the incoming bytes will be first decoded through this
+        pipeline.addLast("decoder", new MQTTDecoder());
+        //MQTTEncoder extends ChannelOutboundHandlerAdapter, the outbound messages will be converted to bytes
+        pipeline.addLast("encoder", new MQTTEncoder());
+        //Once decoded, we need to handle the decoded message and manage the brokering aspect
+        pipeline.addLast("handler", new MqttMessagingHandler());
+
+    }
+
+    static class WebSocketFrameToByteBufDecoder extends MessageToMessageDecoder<BinaryWebSocketFrame> {
+
+        @Override
+        protected void decode(ChannelHandlerContext chc, BinaryWebSocketFrame frame, List<Object> out) throws
+                Exception {
+            //convert the frame to a ByteBuf
+            ByteBuf frameBytes = frame.content();
+            frameBytes.retain();
+            out.add(frameBytes);
+        }
+    }
+
+    static class ByteBufToWebSocketFrameEncoder extends MessageToMessageEncoder<ByteBuf> {
+
+        @Override
+        protected void encode(ChannelHandlerContext chc, ByteBuf bb, List<Object> out) throws Exception {
+            //convert the ByteBuf to a WebSocketFrame
+            BinaryWebSocketFrame result = new BinaryWebSocketFrame();
+            result.content().writeBytes(bb);
+            out.add(result);
+        }
+    }
+
+}

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/AndesAdaptor.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/AndesAdaptor.java
@@ -44,6 +44,7 @@ import org.wso2.carbon.andes.transports.mqtt.adaptors.common.MessageDeliveryTag;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.common.QOSLevel;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.exceptions.AdaptorException;
 import org.wso2.carbon.andes.transports.mqtt.broker.MqttChannel;
+import org.wso2.carbon.andes.transports.mqtt.broker.PublisherAcknowledgementProcessor;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.ConnectMessage;
 
 import java.util.HashMap;
@@ -171,8 +172,12 @@ public class AndesAdaptor implements MessagingAdaptor {
                 publisher.setChannel(publisherChannel);
             }
 
+            PublisherAcknowledgementProcessor pubAckHandler = messageContext.getPubAckHandler();
+            AndesPublisherAcknowledgementProcessor andesPubAckProcessor = new AndesPublisherAcknowledgementProcessor
+                    (pubAckHandler);
+            //We need to wrap the puback handler with the andes implementation
             Andes.getInstance().messageReceived(messageContext.toAndesMessage(),
-                                                publisher.getChannel(), messageContext.getPubAckHandler());
+                                                publisher.getChannel(), andesPubAckProcessor);
             if (log.isDebugEnabled()) {
                 log.debug(" Message added " + messageContext);
             }

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/AndesPublisherAcknowledgementProcessor.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/AndesPublisherAcknowledgementProcessor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.andes.transports.mqtt.adaptors.andes;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.andes.kernel.AndesMessageMetadata;
+import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
+import org.wso2.carbon.andes.transports.mqtt.adaptors.andes.utils.MqttUtils;
+import org.wso2.carbon.andes.transports.mqtt.broker.PublisherAcknowledgementProcessor;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubAckMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubRecMessage;
+
+/**
+ * Handles acknowledgments sent/received by andes
+ */
+public class AndesPublisherAcknowledgementProcessor implements PubAckHandler {
+
+    /**
+     * Holds the protocol level publisher acknowledgment processing
+     */
+    private PublisherAcknowledgementProcessor protocolPublisherAckProcessor;
+
+    private static Log log = LogFactory.getLog(AndesPublisherAcknowledgementProcessor.class);
+
+    public AndesPublisherAcknowledgementProcessor(PublisherAcknowledgementProcessor protocolPublisherAckProcessor) {
+        this.protocolPublisherAckProcessor = protocolPublisherAckProcessor;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void ack(AndesMessageMetadata metadata) {
+        int qos = (Integer) metadata.getTemporaryProperty(MqttUtils.QOSLEVEL);
+        String clientId = (String) metadata.getTemporaryProperty(MqttUtils.CLIENT_ID);
+        Integer messageId = (Integer) metadata.getTemporaryProperty(MqttUtils.MESSAGE_ID);
+
+        if (qos == AbstractMessage.QOSType.EXACTLY_ONCE.getValue()) {
+          /*  PubCompMessage pubCompMessage = new PubCompMessage();
+            pubCompMessage.setMessageID(messageId);*/
+     /*       String publisherKey = messageId + clientId;
+            publishedKeys.add(publisherKey);*/
+            protocolPublisherAckProcessor.addPublisherKey(messageId, clientId);
+            PubRecMessage pubRecMessage = new PubRecMessage();
+            pubRecMessage.setMessageID(messageId);
+            if (log.isDebugEnabled()) {
+                log.debug("Publisher received will be dispatched to message " + messageId + " having the client id " +
+                        clientId);
+            }
+            protocolPublisherAckProcessor.acknowledge(pubRecMessage);
+        } else if (qos == AbstractMessage.QOSType.LEAST_ONE.getValue()) {
+            PubAckMessage pubAckMessage = new PubAckMessage();
+            pubAckMessage.setMessageID(messageId);
+            if (log.isDebugEnabled()) {
+                log.debug("Publisher acknowledgment will be dispatched to message " + messageId + " having the client" +
+                        " id " +
+                        clientId);
+            }
+            protocolPublisherAckProcessor.acknowledge(pubAckMessage);
+        }
+    }
+
+    @Override
+    public void nack(AndesMessageMetadata metadata) {
+
+    }
+}

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/message/MqttMessageContext.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/message/MqttMessageContext.java
@@ -27,7 +27,6 @@ import org.wso2.andes.kernel.AndesMessageMetadata;
 import org.wso2.andes.kernel.AndesMessagePart;
 import org.wso2.andes.kernel.AndesUtils;
 import org.wso2.andes.kernel.ProtocolType;
-import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.andes.utils.MqttUtils;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.common.QOSLevel;
 import org.wso2.carbon.andes.transports.mqtt.broker.PublisherAcknowledgementProcessor;
@@ -70,7 +69,7 @@ public class MqttMessageContext {
     /**
      * The ack handler that will ack for QoS 1 and 2 messages
      */
-    private PubAckHandler pubAckHandler;
+    private PublisherAcknowledgementProcessor pubAckHandler;
     /**
      * The channel used to communicate with the publisher
      */
@@ -198,11 +197,11 @@ public class MqttMessageContext {
         this.publisherID = publisherID;
     }
 
-    public PubAckHandler getPubAckHandler() {
+    public PublisherAcknowledgementProcessor getPubAckHandler() {
         return pubAckHandler;
     }
 
-    public void setPubAckHandler(PubAckHandler pubAckHandler) {
+    public void setPubAckHandler(PublisherAcknowledgementProcessor pubAckHandler) {
         this.pubAckHandler = pubAckHandler;
     }
 

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/subscriptions/MqttLocalSubscription.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/andes/subscriptions/MqttLocalSubscription.java
@@ -176,7 +176,16 @@ public class MqttLocalSubscription implements OutboundSubscription {
             retainMessageIdSet.remove(messageID + channelID.toString());
         } else {*/
         //TODO need to add the retain message logic here
-        Andes.getInstance().ackReceived(andesAckData);
+        Andes instance = Andes.getInstance();
+        if (null != instance) {
+            try {
+                instance.ackReceived(andesAckData);
+            } catch (Exception e) {
+                log.error("Error occurred while connecting to andes ", e);
+            }
+        } else {
+            log.warn("Error occurred when calling the andes API");
+        }
 
         // }
     }

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/memory/MemoryConnector.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/memory/MemoryConnector.java
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.andes.transports.mqtt.adaptors.memory;
 
-import org.wso2.carbon.andes.transports.mqtt.MqttConstants;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.MessagingAdaptor;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.andes.message.MqttMessageContext;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.common.MessageDeliveryTag;
@@ -99,7 +98,7 @@ public class MemoryConnector implements MessagingAdaptor {
         stringMqttChannelMap.remove(clientId);
 
         //If there're no clients for the topic after the disconnection we could remove the topic
-        if(stringMqttChannelMap.size() == 0){
+        if (stringMqttChannelMap.size() == 0) {
             subscriptions.remove(topicName);
         }
     }

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/memory/MemoryConnector.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/adaptors/memory/MemoryConnector.java
@@ -41,12 +41,14 @@ public class MemoryConnector implements MessagingAdaptor {
     /**
      * <p>
      * Holds the list of subscription against its topic
+     * key   - the topic name
+     * value - Map<clientId,channel>
      * </p>
      * <p>
      * <b>Note:</b> in-memory mode will always send/receive from QoS 0
      * </p>
      */
-    private Map<String, Map<String, MqttChannel>> subscriptions = new ConcurrentHashMap<>();
+    protected Map<String, Map<String, MqttChannel>> subscriptions = new ConcurrentHashMap<>();
 
     @Override
     public void storeConnection(ConnectMessage message) throws AdaptorException {
@@ -62,7 +64,7 @@ public class MemoryConnector implements MessagingAdaptor {
             mqttChannels = new HashMap<>();
         }
 
-        mqttChannels.put(mqttChannel.getProperty(MqttConstants.CLIENT_ID_PROPERTY_NAME), mqttChannel);
+        mqttChannels.put(clientId, mqttChannel);
         subscriptions.put(topic, mqttChannels);
     }
 
@@ -95,6 +97,11 @@ public class MemoryConnector implements MessagingAdaptor {
             throws AdaptorException {
         Map<String, MqttChannel> stringMqttChannelMap = subscriptions.get(topicName);
         stringMqttChannelMap.remove(clientId);
+
+        //If there're no clients for the topic after the disconnection we could remove the topic
+        if(stringMqttChannelMap.size() == 0){
+            subscriptions.remove(topicName);
+        }
     }
 
     @Override

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/BrokerVersion.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/BrokerVersion.java
@@ -78,7 +78,7 @@ public enum BrokerVersion {
      * Gets the message adopter implementation
      * @return MessagingAdaptor
      */
-    public MessagingAdaptor getAdaptor(){
+    public MessagingAdaptor getAdaptor() {
         return adaptor;
     }
 

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/BrokerVersion.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/BrokerVersion.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.andes.transports.mqtt.broker;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.andes.transports.mqtt.adaptors.MessagingAdaptor;
+import org.wso2.carbon.andes.transports.mqtt.adaptors.andes.AndesAdaptor;
 import org.wso2.carbon.andes.transports.mqtt.broker.v311.MqttBroker;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.Utils;
 import org.wso2.carbon.andes.transports.server.Broker;
@@ -46,12 +48,19 @@ public enum BrokerVersion {
     private transient Broker broker;
 
     /**
+     * The interface broker would connect to handle storage/distribution
+     */
+    private transient MessagingAdaptor adaptor;
+
+    /**
      * Initializes the version of the broker
      *
      * @param broker the instance of the broker which corresponds to its version
      */
     BrokerVersion(Broker broker) {
         this.broker = broker;
+        //We could get these value based on the configuration
+        this.adaptor = new AndesAdaptor();
     }
 
     /**
@@ -63,6 +72,14 @@ public enum BrokerVersion {
      */
     public Broker getBroker() throws IllegalAccessException, InstantiationException {
         return broker;
+    }
+
+    /**
+     * Gets the message adopter implementation
+     * @return MessagingAdaptor
+     */
+    public MessagingAdaptor getAdaptor(){
+        return adaptor;
     }
 
     /**

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/Command.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/Command.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.andes.transports.mqtt.broker;
 
+import org.wso2.carbon.andes.transports.mqtt.adaptors.MessagingAdaptor;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PingRespMessage;
 import org.wso2.carbon.andes.transports.server.Broker;
@@ -34,62 +35,72 @@ public enum Command {
 
     CONNECT(AbstractMessage.CONNECT) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
             broker.connect(msg, callback);
         }
     },
     DISCONNECT(AbstractMessage.DISCONNECT) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.disconnect(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
+            broker.disconnect(msg, callback, messageAdaptor);
         }
     },
     PUBLISH(AbstractMessage.PUBLISH) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.publish(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
+            broker.publish(msg, callback, messageAdaptor);
         }
     },
     PUBLISHER_ACK(AbstractMessage.PUBACK) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.subAck(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
+            broker.subAck(msg, callback, messageAdaptor);
         }
     },
     PUBLISHER_COMPLETE(AbstractMessage.PUBCOMP) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.subAck(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
+            broker.subAck(msg, callback, messageAdaptor);
         }
     },
     PUBLISHER_RECEIVED(AbstractMessage.PUBREC) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.subAck(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
+            broker.subAck(msg, callback, messageAdaptor);
         }
     },
     PUBLISHER_RELEASE(AbstractMessage.PUBREL) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.pubAck(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messageAdaptor) throws BrokerException {
+            broker.pubAck(msg, callback, messageAdaptor);
         }
     },
     SUBSCRIBE(AbstractMessage.SUBSCRIBE) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.subscribe(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messagingAdaptor) throws BrokerException {
+            broker.subscribe(msg, callback, messagingAdaptor);
         }
     },
     UN_SUBSCRIBE(AbstractMessage.UNSUBSCRIBE) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.unSubscribe(msg, callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messagingAdaptor) throws BrokerException {
+            broker.unSubscribe(msg, callback, messagingAdaptor);
         }
     },
     PINGREQ(AbstractMessage.PINGREQ) {
         @Override
-        public void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException {
-            broker.nack(callback);
+        public void process(Broker broker, AbstractMessage msg, MqttChannel callback,
+                            MessagingAdaptor messagingAdaptor) throws BrokerException {
+            broker.nack(callback, messagingAdaptor);
             PingRespMessage message = new PingRespMessage();
             callback.write(message);
         }
@@ -138,7 +149,9 @@ public enum Command {
      * @param broker         the the implementation of the protocol  i.e MQTT 3.1, MQTT 3.1.1
      * @param msg            message which corresponds to the command
      * @param callback       the channel which the command was sent
+     * @param messageAdaptor the adopter interface the broker connects for storage/distribution
      * @throws BrokerException
      */
-    public abstract void process(Broker broker, AbstractMessage msg, MqttChannel callback) throws BrokerException;
+    public abstract void process(Broker broker, AbstractMessage msg, MqttChannel callback, MessagingAdaptor
+            messageAdaptor) throws BrokerException;
 }

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/MqttChannel.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/MqttChannel.java
@@ -95,7 +95,7 @@ public class MqttChannel {
 
         Queue<MessageDeliveryTag> messageIdList = new ConcurrentLinkedQueue<>();
 
-        //TODO this algorithm should change
+        //TODO this algorithm should change, also we need to add a static initializer here
         //We start the message id with 2, message id 1 will be sent to qos 0 messages
         for (int messageCount = 2; messageCount != Short.MAX_VALUE; messageCount++) {
             MessageDeliveryTag messageDeliveryTag = new MessageDeliveryTag(messageCount);
@@ -109,8 +109,6 @@ public class MqttChannel {
 
         this.deliveryTagMap =  new MessageDeliveryTagMap<>(messageIdList, messageDeliveryTag);
 
-        //Gets the message delivery tag
-       // this.deliveryTagMap = deliveryTagMqttFactory.getMessageDeliveryTagMap();
     }
 
     public SubscriberAcknowledgementProcessor getSubscriberAck() {

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/MqttChannel.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/MqttChannel.java
@@ -80,7 +80,6 @@ public class MqttChannel {
 
     /**
      * Handles subscriber side acknowledgements
-
      */
     private SubscriberAcknowledgementProcessor subscriberAck = new SubscriberAcknowledgementProcessor();
 
@@ -107,7 +106,7 @@ public class MqttChannel {
             return o1.compareTo(o2);
         });
 
-        this.deliveryTagMap =  new MessageDeliveryTagMap<>(messageIdList, messageDeliveryTag);
+        this.deliveryTagMap = new MessageDeliveryTagMap<>(messageIdList, messageDeliveryTag);
 
     }
 
@@ -138,7 +137,6 @@ public class MqttChannel {
     public Integer getTopic(String topic) {
         return topicQoSLevels.get(topic);
     }
-
 
     /**
      * Removes a topic off the list during disconnection/un-subscription

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/PublisherAcknowledgementProcessor.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/PublisherAcknowledgementProcessor.java
@@ -21,19 +21,15 @@ package org.wso2.carbon.andes.transports.mqtt.broker;
 import io.netty.channel.ChannelHandlerContext;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.andes.kernel.AndesMessageMetadata;
-import org.wso2.andes.kernel.disruptor.inbound.PubAckHandler;
-import org.wso2.carbon.andes.transports.mqtt.adaptors.andes.utils.MqttUtils;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
-import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubAckMessage;
-import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubRecMessage;
+
 
 import java.util.TreeSet;
 
 /**
  * Performs operations which involves writing acknowledgments to a given channel for a published message
  */
-public class PublisherAcknowledgementProcessor implements PubAckHandler {
+public class PublisherAcknowledgementProcessor {
 
     private static Log log = LogFactory.getLog(PublisherAcknowledgementProcessor.class);
 
@@ -115,9 +111,9 @@ public class PublisherAcknowledgementProcessor implements PubAckHandler {
         publishedKeys.add(messageId + clientId);
     }
 
-    /**
+/*    *//**
      * {@inheritDoc}
-     */
+     *//*
     @Override
     public void ack(AndesMessageMetadata metadata) {
         int qos = (Integer) metadata.getTemporaryProperty(MqttUtils.QOSLEVEL);
@@ -125,10 +121,10 @@ public class PublisherAcknowledgementProcessor implements PubAckHandler {
         Integer messageId = (Integer) metadata.getTemporaryProperty(MqttUtils.MESSAGE_ID);
 
         if (qos == AbstractMessage.QOSType.EXACTLY_ONCE.ordinal()) {
-          /*  PubCompMessage pubCompMessage = new PubCompMessage();
-            pubCompMessage.setMessageID(messageId);*/
-     /*       String publisherKey = messageId + clientId;
-            publishedKeys.add(publisherKey);*/
+          *//*  PubCompMessage pubCompMessage = new PubCompMessage();
+            pubCompMessage.setMessageID(messageId);*//*
+     *//*       String publisherKey = messageId + clientId;
+            publishedKeys.add(publisherKey);*//*
             addPublisherKey(messageId, clientId);
             PubRecMessage pubRecMessage = new PubRecMessage();
             pubRecMessage.setMessageID(messageId);
@@ -152,5 +148,5 @@ public class PublisherAcknowledgementProcessor implements PubAckHandler {
     @Override
     public void nack(AndesMessageMetadata metadata) {
 
-    }
+    }*/
 }

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/PublisherAcknowledgementProcessor.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/PublisherAcknowledgementProcessor.java
@@ -40,7 +40,7 @@ public class PublisherAcknowledgementProcessor implements PubAckHandler {
     /**
      * TCP channel of the publisher
      */
-    private ChannelHandlerContext channel;
+    ChannelHandlerContext channel;
 
     /**
      * <p>
@@ -106,6 +106,16 @@ public class PublisherAcknowledgementProcessor implements PubAckHandler {
     }
 
     /**
+     * Adds the publisher key which is messageId + clientId
+     *
+     * @param messageId the id of the message
+     * @param clientId  the id of the client
+     */
+    public void addPublisherKey(Integer messageId, String clientId) {
+        publishedKeys.add(messageId + clientId);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
@@ -115,8 +125,11 @@ public class PublisherAcknowledgementProcessor implements PubAckHandler {
         Integer messageId = (Integer) metadata.getTemporaryProperty(MqttUtils.MESSAGE_ID);
 
         if (qos == AbstractMessage.QOSType.EXACTLY_ONCE.ordinal()) {
-            String publisherKey = messageId + clientId;
-            publishedKeys.add(publisherKey);
+          /*  PubCompMessage pubCompMessage = new PubCompMessage();
+            pubCompMessage.setMessageID(messageId);*/
+     /*       String publisherKey = messageId + clientId;
+            publishedKeys.add(publisherKey);*/
+            addPublisherKey(messageId, clientId);
             PubRecMessage pubRecMessage = new PubRecMessage();
             pubRecMessage.setMessageID(messageId);
             if (log.isDebugEnabled()) {

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/v311/commands/Disconnect.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/broker/v311/commands/Disconnect.java
@@ -45,14 +45,10 @@ public class Disconnect {
      * @return Subscribe
      */
     public static boolean notifyStore(MessagingAdaptor messageStore, MqttChannel channel)
-            throws
-            BrokerException {
-
-        //  String mqttClientChannelID = channel.getProperty(MqttConstants.CLIENT_ID_PROPERTY_NAME);
+            throws BrokerException {
 
         try {
             //We need to also consider publisher disconnections here and clear the state
-            // publisherAckReceiver.disconnectionPublisher(mqttClientChannelID);
             boolean isCleanSession = Boolean.parseBoolean(channel.getProperty(MqttConstants
                     .SESSION_DURABILITY_PROPERTY_NAME));
             String subscriptionId = channel.getProperty(MqttUtils.CLUSTER_SUB_ID_PROPERTY_NAME);

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/internal/MqttTransportServiceComponent.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/internal/MqttTransportServiceComponent.java
@@ -39,10 +39,8 @@ import org.wso2.carbon.andes.transports.config.MqttTransportConfiguration;
 import org.wso2.carbon.andes.transports.config.MqttTransportProperties;
 import org.wso2.carbon.andes.transports.config.MqttWebsocketTransportProperties;
 import org.wso2.carbon.andes.transports.config.YAMLTransportConfigurationBuilder;
-import org.wso2.carbon.andes.transports.mqtt.MqttSSLServer;
 import org.wso2.carbon.andes.transports.mqtt.MqttServer;
 import org.wso2.carbon.andes.transports.mqtt.MqttWebSocketServer;
-import org.wso2.carbon.andes.transports.mqtt.Util;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.andes.subscriptions.MQTTopicSubscriptionBitMapStore;
 import org.wso2.carbon.andes.transports.mqtt.broker.BrokerVersion;
 import org.wso2.carbon.andes.transports.server.Server;
@@ -125,7 +123,7 @@ public class MqttTransportServiceComponent {
         processConfiguration(mqttSecuredTransportProperties);
         mqttSecuredTransportProperties.setProtocol(MqttTransport.PROTOCOL_NAME);
 
-        MqttSSLServer securedMqttServer = new MqttSSLServer(Util.getSSLConfig(mqttSecuredTransportProperties));
+   //     MqttSSLServer securedMqttServer = new MqttSSLServer(Util.getSSLConfig(mqttSecuredTransportProperties));
 
         MqttWebsocketTransportProperties websocketTransportProperties = mqttTransportConfiguration
                 .getMqttWebsocketTransportProperties();
@@ -137,7 +135,7 @@ public class MqttTransportServiceComponent {
 
         //Creates a transport from the given configuration
         MqttTransport transport = new MqttTransport(mqttTransportProperties, mqttServer);
-        MqttTransport securedTransport = new MqttTransport(mqttSecuredTransportProperties, securedMqttServer);
+//        MqttTransport securedTransport = new MqttTransport(mqttSecuredTransportProperties, securedMqttServer);
         MqttTransport webSocketTransport = new MqttTransport(websocketTransportProperties, webSocketServer);
 
 

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/netty/handlers/MqttMessagingHandler.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/mqtt/netty/handlers/MqttMessagingHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.andes.transports.mqtt.adaptors.MessagingAdaptor;
 import org.wso2.carbon.andes.transports.mqtt.broker.BrokerVersion;
 import org.wso2.carbon.andes.transports.mqtt.broker.Command;
 import org.wso2.carbon.andes.transports.mqtt.broker.MqttChannel;
@@ -83,7 +84,8 @@ public class MqttMessagingHandler extends ChannelInboundHandlerAdapter {
 
         //Will identify where the message should flow
         Broker broker = channel.getVersion().getBroker();
-        Command.getCommand(mqttMessage.getMessageType()).process(broker, mqttMessage, channel);
+        MessagingAdaptor adaptor = channel.getVersion().getAdaptor();
+        Command.getCommand(mqttMessage.getMessageType()).process(broker, mqttMessage, channel, adaptor);
 
     }
 
@@ -98,7 +100,8 @@ public class MqttMessagingHandler extends ChannelInboundHandlerAdapter {
         log.info("Netty Channel " + ctx.name() + " got inactive");
         // MqttChannel channel = channelManager.removeChannel(ctx);
         if (null != channel) {
-            channel.getVersion().getBroker().disconnect(null, channel);
+            MessagingAdaptor adaptor = channel.getVersion().getAdaptor();
+            channel.getVersion().getBroker().disconnect(null, channel, adaptor);
             //brokerFactory.getBroker(channel.getVersion()).disconnect(null, channel);
         } else {
             if (log.isDebugEnabled()) {

--- a/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/server/Broker.java
+++ b/carbon-mb/components/transports/mqtt/src/main/java/org/wso2/carbon/andes/transports/server/Broker.java
@@ -18,17 +18,16 @@
 
 package org.wso2.carbon.andes.transports.server;
 
+import org.wso2.carbon.andes.transports.mqtt.adaptors.MessagingAdaptor;
 import org.wso2.carbon.andes.transports.mqtt.broker.MqttChannel;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
 
 /**
- * The abstraction between the protocol layer and the brokering
- * The following defines a set of services common to all the brokering transports
- * The following should be implemented to connect with the underlying brokering engine
- * Through this we could abstract the decoding with protocol semantics i.e having different semantics between different
- * versions
+ * Handles polymorphic behaviour represented through each version of the MQTT protocol
+ *
+ * @param <K> defines the message adopter the broker will be connecting
  */
-public interface Broker {
+public interface Broker<K extends MessagingAdaptor> {
     /**
      * Triggers the connectivity with the broker
      *
@@ -41,61 +40,68 @@ public interface Broker {
     /**
      * Triggers when disconnected with the broker
      *
-     * @param msg     the details of the message which holds the disconnection
-     * @param channel provides the details of the client connection which should be disconnected
+     * @param msg            the details of the message which holds the disconnection
+     * @param channel        provides the details of the client connection which should be disconnected
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void disconnect(AbstractMessage msg, MqttChannel channel) throws BrokerException;
+    void disconnect(AbstractMessage msg, MqttChannel channel, K messageAdaptor) throws BrokerException;
 
     /**
-     * Triggers when callback is bound
+     * Triggers when a client sends a subscriber message
      *
-     * @param msg      the details of the message which holds the un-callback
-     * @param callback internal channel used to send the SUBACK and message
+     * @param msg            the details of the message which holds the un-callback
+     * @param callback       internal channel used to send the SUBACK and message
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void subscribe(AbstractMessage msg, MqttChannel callback) throws BrokerException;
+    void subscribe(AbstractMessage msg, MqttChannel callback, K messageAdaptor) throws BrokerException;
 
     /**
      * Triggers when un-subscribed from the broker
      *
-     * @param msg      the details of the message when un-subscribed
-     * @param callback used to send the UNSUBACK
+     * @param msg            the details of the message when un-subscribed
+     * @param callback       used to send the UNSUBACK
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void unSubscribe(AbstractMessage msg, MqttChannel callback) throws BrokerException;
+    void unSubscribe(AbstractMessage msg, MqttChannel callback, K messageAdaptor) throws BrokerException;
 
     /**
      * Triggers when a message is published
      *
-     * @param msg      the details of the message when a message is published
-     * @param callback used to send the PUBACK, this will be the most immediate ack
+     * @param msg            the details of the message when a message is published
+     * @param callback       used to send the PUBACK, this will be the most immediate ack
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void publish(AbstractMessage msg, MqttChannel callback) throws BrokerException;
+    void publish(AbstractMessage msg, MqttChannel callback, K messageAdaptor) throws BrokerException;
 
     /**
      * Triggers each time when a publisher acknowledgment is received
      *
-     * @param msg      details of the message when publisher acknowledges
-     * @param callback will be used to send the acknowledgment to the sender
+     * @param msg            details of the message when publisher acknowledges
+     * @param callback       will be used to send the acknowledgment to the sender
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void pubAck(AbstractMessage msg, MqttChannel callback) throws BrokerException;
+    void pubAck(AbstractMessage msg, MqttChannel callback, K messageAdaptor) throws BrokerException;
 
     /**
-     * @param msg      the message which contains the subscription acknowledgments
-     * @param callback the channel which will allow the server to add correspondence
+     * @param msg            the message which contains the subscription acknowledgments
+     * @param callback       the channel which will allow the server to add correspondence
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void subAck(AbstractMessage msg, MqttChannel callback) throws BrokerException;
+    void subAck(AbstractMessage msg, MqttChannel callback, K messageAdaptor) throws BrokerException;
 
     /**
      * Negative acknowledgment or specifying to process un acknowledged messages
      *
-     * @param callback specifies the channel information
+     * @param callback       specifies the channel information
+     * @param messageAdaptor the underlying broker store/distribution layer
      * @throws BrokerException
      */
-    void nack(MqttChannel callback) throws BrokerException;
+    void nack(MqttChannel callback, K messageAdaptor) throws BrokerException;
 
 }

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/MqttBrokerTest.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/MqttBrokerTest.java
@@ -17,8 +17,6 @@
 package org.wso2.carbon.transport.tests.mqtt.broker.v311;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.andes.transports.mqtt.MqttConstants;
 import org.wso2.carbon.andes.transports.mqtt.adaptors.common.QOSLevel;
@@ -27,8 +25,6 @@ import org.wso2.carbon.andes.transports.mqtt.broker.v311.MqttBroker;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.ConnAckMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.DisconnectMessage;
-import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubRecMessage;
-import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubRelMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PublishMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubAckMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubscribeMessage;
@@ -47,15 +43,6 @@ import java.util.List;
  * Tests Mqtt broker command messages
  */
 public class MqttBrokerTest {
-    @BeforeMethod
-    public void setUp() throws Exception {
-
-    }
-
-    @AfterMethod
-    public void tearDown() throws Exception {
-
-    }
 
     /**
      * Will create a broker instance and get the relevant response for the command message
@@ -70,6 +57,12 @@ public class MqttBrokerTest {
         return clientMessageReceiver.getResponseMessage();
     }
 
+    /**
+     * Tests MQTT connect message command
+     *
+     * @param connection the connection information which includes connection flags
+     * @throws Exception
+     */
     @Test(dataProvider = "ConnectMessage", dataProviderClass = MqttBrokerDataProvider.class)
     public void testConnect(Message connection) throws Exception {
         AbstractMessage responseMessage = createBrokerAndGetResponse(connection);
@@ -83,6 +76,12 @@ public class MqttBrokerTest {
         }
     }
 
+    /**
+     * Tests MQTT disconnection message command
+     *
+     * @param disconnection the disconnection information
+     * @throws Exception
+     */
     @Test(dataProvider = "DisconnectMessage", dataProviderClass = MqttBrokerDataProvider.class)
     public void testDisconnect(Message disconnection) throws Exception {
         //We need to declare a message adopter, message adopter would be responsible to maintain the state
@@ -97,6 +96,8 @@ public class MqttBrokerTest {
         int qos = Integer.parseInt(disconnection.getMessageProperty("qosLevel"));
         QOSLevel qosLevel = QOSLevel.getQoSFromValue(qos);
         boolean session = Boolean.parseBoolean(disconnection.getMessageProperty("session"));
+
+
         MqttChannel mqttChannel = clientMessageReceiver.getMqttChannel();
         adopter.storeSubscriptions(topicFilter, clientId, userName, session, qosLevel, mqttChannel);
         //We need to reflect those subscriptions in the channel
@@ -112,6 +113,12 @@ public class MqttBrokerTest {
 
     }
 
+    /**
+     * Test subscription command messages
+     *
+     * @param subscribe holds the commands releated to the subscription
+     * @throws Exception
+     */
     @Test(dataProvider = "SubscribeMessage", dataProviderClass = MqttBrokerDataProvider.class)
     public void testSubscribe(Message subscribe) throws Exception {
         MqttBroker broker = new MqttBroker();
@@ -136,6 +143,12 @@ public class MqttBrokerTest {
     }
 
 
+    /**
+     * Test un subscription command message
+     *
+     * @param unSubscribe holds the un-subscription command message information
+     * @throws Exception
+     */
     @Test(dataProvider = "unSubscribeMessage", dataProviderClass = MqttBrokerDataProvider.class)
     public void testUnSubscribe(Message unSubscribe) throws Exception {
         MqttBroker broker = new MqttBroker();
@@ -165,6 +178,12 @@ public class MqttBrokerTest {
 
     }
 
+    /**
+     * Test message publish command
+     *
+     * @param publishMessage the information related to the published message
+     * @throws Exception
+     */
     @Test(dataProvider = "PublishMessage", dataProviderClass = MqttBrokerDataProvider.class)
     public void testPublish(Message publishMessage) throws Exception {
         MqttBroker broker = new MqttBroker();
@@ -182,24 +201,4 @@ public class MqttBrokerTest {
         }
     }
 
-    @Test(dataProvider = "PublisherAckMessage", dataProviderClass = MqttBrokerDataProvider.class)
-    public void testPubAck(Message pubAckMessage) throws Exception {
-        MqttBroker broker = new MqttBroker();
-        PubRelMessage message = (PubRelMessage) pubAckMessage.getMessage();
-        //PRE-REQUESTS - this message is sent by the publisher to the broker for QoS 2 messages
-        // The message should receive the PUBREC from the publisher
-        PubRecMessage pubRecMessage = new PubRecMessage();
-        //Need to check whether the state didn't invary
-        //broker.pubAck();
-    }
-
-    @Test
-    public void testSubAck() throws Exception {
-
-    }
-
-    @Test
-    public void testNack() throws Exception {
-
-    }
 }

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/MqttBrokerTest.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/MqttBrokerTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.carbon.transport.tests.mqtt.broker.v311;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.andes.transports.mqtt.MqttConstants;
+import org.wso2.carbon.andes.transports.mqtt.adaptors.common.QOSLevel;
+import org.wso2.carbon.andes.transports.mqtt.broker.MqttChannel;
+import org.wso2.carbon.andes.transports.mqtt.broker.v311.MqttBroker;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.ConnAckMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.DisconnectMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PublishMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubAckMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubscribeMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.UnsubAckMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.UnsubscribeMessage;
+import org.wso2.carbon.andes.transports.server.BrokerException;
+import org.wso2.carbon.kernel.runtime.exception.RuntimeServiceException;
+import org.wso2.carbon.transport.tests.mqtt.broker.v311.adaptors.MockMemoryAdaptor;
+import org.wso2.carbon.transport.tests.mqtt.broker.v311.client.ClientMessageReceiver;
+import org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider.MqttBrokerDataProvider;
+import org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider.commands.Message;
+
+import java.util.List;
+
+/**
+ * Tests Mqtt broker command messages
+ */
+public class MqttBrokerTest {
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+    }
+
+    /**
+     * Will create a broker instance and get the relevant response for the command message
+     *
+     * @param command MQTT command message
+     * @return response message which will represent the ack which will be sent to the client
+     */
+    private AbstractMessage createBrokerAndGetResponse(Message command) throws BrokerException {
+        ClientMessageReceiver clientMessageReceiver = new ClientMessageReceiver();
+        MqttBroker broker = new MqttBroker();
+        broker.connect(command.getMessage(), clientMessageReceiver.getMqttChannel());
+        return clientMessageReceiver.getResponseMessage();
+    }
+
+    @Test(dataProvider = "ConnectMessage", dataProviderClass = MqttBrokerDataProvider.class)
+    public void testConnect(Message connection) throws Exception {
+        AbstractMessage responseMessage = createBrokerAndGetResponse(connection);
+        byte expectedResult = (byte) connection.getExpectedResult();
+
+        if (responseMessage instanceof ConnAckMessage) {
+            byte returnCode = ((ConnAckMessage) responseMessage).getReturnCode();
+            Assert.assertEquals(returnCode, expectedResult);
+        } else {
+            throw new RuntimeServiceException("Error occurred while casting the acknowledgment");
+        }
+    }
+
+    @Test(dataProvider = "DisconnectMessage", dataProviderClass = MqttBrokerDataProvider.class)
+    public void testDisconnect(Message disconnection) throws Exception {
+        //We need to declare a message adopter, message adopter would be responsible to maintain the state
+        MockMemoryAdaptor adopter = new MockMemoryAdaptor();
+        ClientMessageReceiver clientMessageReceiver = new ClientMessageReceiver();
+        DisconnectMessage disconnectMessage = (DisconnectMessage) disconnection.getMessage();
+
+        //Before testing the disconnection we need to create a connection
+        String clientId = disconnection.getMessageProperty("Client-ID");
+        String topicFilter = disconnection.getMessageProperty("topicFilter");
+        String userName = disconnection.getMessageProperty("userName");
+        int qos = Integer.parseInt(disconnection.getMessageProperty("qosLevel"));
+        QOSLevel qosLevel = QOSLevel.getQoSFromValue(qos);
+        boolean session = Boolean.parseBoolean(disconnection.getMessageProperty("session"));
+        MqttChannel mqttChannel = clientMessageReceiver.getMqttChannel();
+        adopter.storeSubscriptions(topicFilter, clientId, userName, session, qosLevel, mqttChannel);
+        //We need to reflect those subscriptions in the channel
+        clientMessageReceiver.getMqttChannel().addTopic(topicFilter, qos);
+        clientMessageReceiver.getMqttChannel().addProperty(MqttConstants.CLIENT_ID_PROPERTY_NAME, clientId);
+
+
+        MqttBroker broker = new MqttBroker();
+        broker.disconnect(disconnectMessage, mqttChannel, adopter);
+
+        //We now need to check against the store whether the disconnection is successful
+        Assert.assertTrue(!adopter.isSubscriptionLive(topicFilter, clientId));
+
+    }
+
+    @Test(dataProvider = "SubscribeMessage", dataProviderClass = MqttBrokerDataProvider.class)
+    public void testSubscribe(Message subscribe) throws Exception {
+        MqttBroker broker = new MqttBroker();
+        MockMemoryAdaptor adopter = new MockMemoryAdaptor();
+        ClientMessageReceiver messageReceiver = new ClientMessageReceiver();
+        SubscribeMessage message = (SubscribeMessage) subscribe.getMessage();
+        MqttChannel mqttChannel = messageReceiver.getMqttChannel();
+
+        broker.subscribe(message, mqttChannel, adopter);
+
+        SubAckMessage responseMessage = (SubAckMessage) messageReceiver.getResponseMessage();
+
+        List<AbstractMessage.QOSType> types = responseMessage.types();
+
+        //We need to compare whether the expected result is obtained, 1 means expects the subscription to succeed 2
+        // means expects the subscription to fail
+        int expectedSubscriptionCount = (int) subscribe.getExpectedResult();
+        int actualResult = types.size();
+
+        Assert.assertTrue(expectedSubscriptionCount == actualResult);
+
+    }
+
+
+    @Test(dataProvider = "unSubscribeMessage", dataProviderClass = MqttBrokerDataProvider.class)
+    public void testUnSubscribe(Message unSubscribe) throws Exception {
+        MqttBroker broker = new MqttBroker();
+        ClientMessageReceiver messageReceiver = new ClientMessageReceiver();
+        MockMemoryAdaptor adaptor = new MockMemoryAdaptor();
+        UnsubscribeMessage unSubscriptionMessage = (UnsubscribeMessage) unSubscribe.getMessage();
+        MqttChannel mqttChannel = messageReceiver.getMqttChannel();
+        //Before un-subscribing we need to subscribe first
+        //Before testing the disconnection we need to create a connection
+        String clientId = unSubscribe.getMessageProperty("Client-ID");
+        String topicFilter = unSubscribe.getMessageProperty("topicFilter");
+        String userName = unSubscribe.getMessageProperty("userName");
+        int qos = Integer.parseInt(unSubscribe.getMessageProperty("qosLevel"));
+        QOSLevel qosLevel = QOSLevel.getQoSFromValue(qos);
+        boolean session = Boolean.parseBoolean(unSubscribe.getMessageProperty("session"));
+        messageReceiver.getMqttChannel().addTopic(topicFilter, qos);
+        messageReceiver.getMqttChannel().addProperty(MqttConstants.CLIENT_ID_PROPERTY_NAME, clientId);
+        adaptor.storeSubscriptions(topicFilter, clientId, userName, session, qosLevel, mqttChannel);
+
+        broker.unSubscribe(unSubscriptionMessage, mqttChannel, adaptor);
+
+        //We need to check whether the unsubscribe ack was received
+        AbstractMessage responseMessage = messageReceiver.getResponseMessage();
+
+        Assert.assertTrue((responseMessage != null && responseMessage instanceof UnsubAckMessage) && !adaptor
+                .isSubscriptionLive(topicFilter, clientId));
+
+    }
+
+    @Test(dataProvider = "PublishMessage", dataProviderClass = MqttBrokerDataProvider.class)
+    public void testPublish(Message publishMessage) throws Exception {
+        MqttBroker broker = new MqttBroker();
+        ClientMessageReceiver messageReceiver = new ClientMessageReceiver();
+        MockMemoryAdaptor adaptor = new MockMemoryAdaptor();
+        PublishMessage message = (PublishMessage) publishMessage.getMessage();
+        MqttChannel mqttChannel = messageReceiver.getMqttChannel();
+
+        broker.publish(message, mqttChannel, adaptor);
+
+        if (message.getQos().getValue() > AbstractMessage.QOSType.MOST_ONE.getValue()) {
+            //Here we need to validate whether the acknowledgment is sent properly
+            AbstractMessage responseMessage = messageReceiver.getResponseMessage();
+        }
+    }
+
+    @Test(dataProvider = "PublisherAckMessage", dataProviderClass = MqttBrokerDataProvider.class)
+    public void testPubAck() throws Exception {
+        MqttBroker broker = new MqttBroker();
+
+    }
+
+    @Test
+    public void testSubAck() throws Exception {
+
+    }
+
+    @Test
+    public void testNack() throws Exception {
+
+    }
+}

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/MqttBrokerTest.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/MqttBrokerTest.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.andes.transports.mqtt.broker.v311.MqttBroker;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.ConnAckMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.DisconnectMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubRecMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PubRelMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PublishMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubAckMessage;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubscribeMessage;
@@ -176,13 +178,19 @@ public class MqttBrokerTest {
         if (message.getQos().getValue() > AbstractMessage.QOSType.MOST_ONE.getValue()) {
             //Here we need to validate whether the acknowledgment is sent properly
             AbstractMessage responseMessage = messageReceiver.getResponseMessage();
+            AbstractMessage.QOSType qos = responseMessage.getQos();
         }
     }
 
     @Test(dataProvider = "PublisherAckMessage", dataProviderClass = MqttBrokerDataProvider.class)
-    public void testPubAck() throws Exception {
+    public void testPubAck(Message pubAckMessage) throws Exception {
         MqttBroker broker = new MqttBroker();
-
+        PubRelMessage message = (PubRelMessage) pubAckMessage.getMessage();
+        //PRE-REQUESTS - this message is sent by the publisher to the broker for QoS 2 messages
+        // The message should receive the PUBREC from the publisher
+        PubRecMessage pubRecMessage = new PubRecMessage();
+        //Need to check whether the state didn't invary
+        //broker.pubAck();
     }
 
     @Test

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/adaptors/MockMemoryAdaptor.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/adaptors/MockMemoryAdaptor.java
@@ -40,11 +40,12 @@ public class MockMemoryAdaptor extends MemoryConnector {
 
     /**
      * Returns a verification on existence of live subscription for the topic
+     *
      * @param topicName the name of the topic
-     * @param clientId the id of the client who disconnected from the topic
+     * @param clientId  the id of the client who disconnected from the topic
      * @return true if the subscription is alive
      */
-    public boolean isSubscriptionLive(String topicName,String clientId){
+    public boolean isSubscriptionLive(String topicName, String clientId) {
         Map<String, MqttChannel> stringMqttChannelMap = subscriptions.get(topicName);
         MqttChannel channel = null;
         if (stringMqttChannelMap != null) {

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/adaptors/MockMemoryAdaptor.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/adaptors/MockMemoryAdaptor.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.tests.mqtt.broker.v311.adaptors;
+
+import org.wso2.carbon.andes.transports.mqtt.adaptors.memory.MemoryConnector;
+import org.wso2.carbon.andes.transports.mqtt.broker.MqttChannel;
+
+import java.util.Map;
+
+/**
+ * Mocks the memory adopter for mock testing
+ */
+public class MockMemoryAdaptor extends MemoryConnector {
+
+    /**
+     * Returns a verification on existance of a subscription
+     *
+     * @param topicName the name of the topic
+     * @return true if the subscription exists for the given topic
+     */
+    public boolean hasSubscriber(String topicName) {
+        return subscriptions.get(topicName) != null;
+    }
+
+    /**
+     * Returns a verification on existence of live subscription for the topic
+     * @param topicName the name of the topic
+     * @param clientId the id of the client who disconnected from the topic
+     * @return true if the subscription is alive
+     */
+    public boolean isSubscriptionLive(String topicName,String clientId){
+        Map<String, MqttChannel> stringMqttChannelMap = subscriptions.get(topicName);
+        MqttChannel channel = null;
+        if (stringMqttChannelMap != null) {
+            channel = stringMqttChannelMap.get(clientId);
+        }
+        return channel != null;
+    }
+}

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/client/ClientMessageReceiver.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/client/ClientMessageReceiver.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.tests.mqtt.broker.v311.client;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.wso2.carbon.andes.transports.mqtt.broker.MqttChannel;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
+
+/**
+ * Would receive the responseMessage from the given channel, This mocks MQTT client interface
+ */
+public class ClientMessageReceiver {
+    /**
+     * Would hold the responseMessage the client would receive from the server
+     */
+    private AbstractMessage responseMessage;
+
+
+    private MqttChannel mqttChannel;
+
+
+    public ClientMessageReceiver() {
+        //For each client created there should be a mock client channel
+        ChannelHandlerContext mockClientConnection = createMockClientConnection();
+        this.mqttChannel = new MqttChannel(mockClientConnection);
+    }
+
+    /**
+     * Would return a mock client connection
+     *
+     * @return ChannelHandlerContext
+     */
+    private ChannelHandlerContext createMockClientConnection() {
+
+        ChannelHandlerContext channel = Mockito.mock(ChannelHandlerContext.class);
+
+        //Specifies to write the responseMessage to the given channel
+        Mockito.when(channel.writeAndFlush(Matchers.anyObject())).thenAnswer(new Answer<ChannelFuture>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public ChannelFuture answer(InvocationOnMock invocationOnMock) throws Throwable {
+                Object[] inputValues = invocationOnMock.getArguments();
+                receive((AbstractMessage) inputValues[0]);
+                return null;
+            }
+        });
+
+        return channel;
+
+    }
+
+    /**
+     * Message which will be dispatched form the server to the client
+     *
+     * @param incomingMessage MQTT command responseMessage
+     */
+    private void receive(AbstractMessage incomingMessage) {
+        this.responseMessage = incomingMessage;
+    }
+
+    public AbstractMessage getResponseMessage() {
+        return responseMessage;
+    }
+
+    public MqttChannel getMqttChannel() {
+        return mqttChannel;
+    }
+}

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/MqttBrokerDataProvider.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/MqttBrokerDataProvider.java
@@ -18,10 +18,14 @@
 
 package org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider;
 
-import org.omg.CosNaming.NamingContextExtPackage.StringNameHelper;
 import org.testng.annotations.DataProvider;
 import org.wso2.carbon.andes.transports.mqtt.netty.protocol.Utils;
-import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.*;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.ConnAckMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.ConnectMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.PublishMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.SubscribeMessage;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.UnsubscribeMessage;
 import org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider.commands.Message;
 
 import java.nio.ByteBuffer;

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/MqttBrokerDataProvider.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/MqttBrokerDataProvider.java
@@ -36,9 +36,9 @@ import java.nio.ByteBuffer;
 public class MqttBrokerDataProvider {
 
     /**
-     * Message information, holds tests relevant for creating a connection
+     * Holds different combinations of connection commands which will be injected to the tests
      *
-     * @return the list of test cases to create connection
+     * @return the list of connect messages
      */
     @DataProvider(name = "ConnectMessage")
     public static Object[][] getConnectionInformation() {
@@ -55,9 +55,9 @@ public class MqttBrokerDataProvider {
 
 
     /**
-     * Disconnection information, holds information to create tests for disconnection
+     * Holds different combinations of disconnection commands
      *
-     * @return the list of test cases to create disconnection
+     * @return list of disconnection messages
      */
     @DataProvider(name = "DisconnectMessage")
     public static Object[][] getDisconnectionInformation() {
@@ -66,6 +66,11 @@ public class MqttBrokerDataProvider {
         return mockDisconnectionObjects;
     }
 
+    /**
+     * Holds different combinations of subscription message commands
+     *
+     * @return list of subscription messages
+     */
     @DataProvider(name = "SubscribeMessage")
     public static Object[][] getSubscriptionInformation() {
         Message subscribeMessage = createSubscribeMessage();
@@ -73,6 +78,11 @@ public class MqttBrokerDataProvider {
         return mockSubscription;
     }
 
+    /**
+     * Holds different combinations of un-subscription message commands
+     *
+     * @return list of un subscription messages
+     */
     @DataProvider(name = "unSubscribeMessage")
     public static Object[][] getUnsubscriptionInformation() {
         Message unSubscribeMessage = createUnsubscribeMessage();
@@ -80,6 +90,11 @@ public class MqttBrokerDataProvider {
         return unSubscribe;
     }
 
+    /**
+     * Holds different combinations of publish messages
+     *
+     * @return list of publish messages
+     */
     @DataProvider(name = "PublishMessage")
     public static Object[][] getPublishInformation() {
         Message publishMessage = createPublishMessage();
@@ -87,6 +102,11 @@ public class MqttBrokerDataProvider {
         return publishMessageInformation;
     }
 
+    /**
+     * Creates publish message
+     *
+     * @return mock publish message
+     */
     private static Message createPublishMessage() {
         PublishMessage message = new PublishMessage();
         message.setPayload(ByteBuffer.wrap("TestMessage".getBytes()));

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/MqttBrokerDataProvider.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/MqttBrokerDataProvider.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider;
+
+import org.omg.CosNaming.NamingContextExtPackage.StringNameHelper;
+import org.testng.annotations.DataProvider;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.Utils;
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.*;
+import org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider.commands.Message;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Specifies the data providers for Mqtt broker, used for unit testing
+ */
+public class MqttBrokerDataProvider {
+
+    /**
+     * Message information, holds tests relevant for creating a connection
+     *
+     * @return the list of test cases to create connection
+     */
+    @DataProvider(name = "ConnectMessage")
+    public static Object[][] getConnectionInformation() {
+
+        Message mqttCleanSessionClient = createConnectMessage(true, "MqttCleanSessionClient", Utils
+                .VERSION_3_1, ConnAckMessage.CONNECTION_ACCEPTED);
+        Message mqttDurableClient = createConnectMessage(false, "MqttDurableClient", Utils.VERSION_3_1,
+                ConnAckMessage.CONNECTION_ACCEPTED);
+
+        Object[][] mockConnectionObjects = new Object[][]{{mqttCleanSessionClient}, {mqttDurableClient}};
+
+        return mockConnectionObjects;
+    }
+
+
+    /**
+     * Disconnection information, holds information to create tests for disconnection
+     *
+     * @return the list of test cases to create disconnection
+     */
+    @DataProvider(name = "DisconnectMessage")
+    public static Object[][] getDisconnectionInformation() {
+        Message disconnectionMessage = createDisconnectionMessage();
+        Object[][] mockDisconnectionObjects = new Object[][]{{disconnectionMessage}};
+        return mockDisconnectionObjects;
+    }
+
+    @DataProvider(name = "SubscribeMessage")
+    public static Object[][] getSubscriptionInformation() {
+        Message subscribeMessage = createSubscribeMessage();
+        Object[][] mockSubscription = new Object[][]{{subscribeMessage}};
+        return mockSubscription;
+    }
+
+    @DataProvider(name = "unSubscribeMessage")
+    public static Object[][] getUnsubscriptionInformation() {
+        Message unSubscribeMessage = createUnsubscribeMessage();
+        Object[][] unSubscribe = new Object[][]{{unSubscribeMessage}};
+        return unSubscribe;
+    }
+
+    @DataProvider(name = "PublishMessage")
+    public static Object[][] getPublishInformation() {
+        Message publishMessage = createPublishMessage();
+        Object[][] publishMessageInformation = new Object[][]{{publishMessage}};
+        return publishMessageInformation;
+    }
+
+    private static Message createPublishMessage() {
+        PublishMessage message = new PublishMessage();
+        message.setPayload(ByteBuffer.wrap("TestMessage".getBytes()));
+        message.setMessageID(1);
+        message.setTopicName("testPublishTopic");
+        message.setQos(AbstractMessage.QOSType.valueOf(0));
+
+        Message publishMessage = new Message(message, null);
+
+        return publishMessage;
+    }
+
+    /**
+     * Creates a message which would un-subscribe a subscription from the list
+     *
+     * @return the message which holds the subscription
+     */
+    private static Message createUnsubscribeMessage() {
+
+        UnsubscribeMessage unSubscribeMessage = new UnsubscribeMessage();
+        unSubscribeMessage.addTopicFilter("unSubscriptionTestTopic");
+
+        boolean shouldSubscriptionFail = true;
+        Message unSubscribe = new Message(unSubscribeMessage, shouldSubscriptionFail);
+        //We also need to create a subscription to un-subscribe
+        addMockSubscriber("unSubscriptionTestTopic", "unSubsscriptionTestClient", "testUser", "true", "0", unSubscribe);
+
+        return unSubscribe;
+    }
+
+    /**
+     * Creates a subscription message
+     *
+     * @return message which holds the topic and the subscription
+     */
+    private static Message createSubscribeMessage() {
+        int qos = 0;
+        String topic = "testSubscriptionTopic";
+        boolean dupFlag = true;
+        int messageID = 1;
+        int expectedResult = 1;
+
+        SubscribeMessage subscribeMessage = new SubscribeMessage();
+        Message message = new Message(subscribeMessage, expectedResult);
+        SubscribeMessage.Couple subscription = new SubscribeMessage.Couple((byte) qos, topic);
+        subscribeMessage.setDupFlag(dupFlag);
+        subscribeMessage.setMessageID(messageID);
+        subscribeMessage.addSubscription(subscription);
+
+
+        return message;
+    }
+
+    /**
+     * Creates disconnect messages
+     *
+     * @return the message require to form a disconnection
+     */
+    private static Message createDisconnectionMessage() {
+        Message disconnection = new Message();
+        addMockSubscriber("DisconnectionTestTopic", "MqttDisconnectClientId", "testUser", "true", "0", disconnection);
+        return disconnection;
+    }
+
+    private static void addMockSubscriber(String topicFilter, String clientId, String userName, String session, String
+            qos, Message message) {
+        message.addMessageProperty("Client-ID", clientId);
+        message.addMessageProperty("topicFilter", topicFilter);
+        message.addMessageProperty("userName", userName);
+        message.addMessageProperty("session", session);
+        message.addMessageProperty("qosLevel", qos);
+    }
+
+    /**
+     * Creates a MQTT connect message
+     *
+     * @param cleanSession    whether the message is durable
+     * @param clientId        the unique id of the client which connect with the broker
+     * @param protocolVersion the protocol version i.e 3.1v,3.1.1v
+     * @param expected        the expected result of the message
+     * @return the client mock connection
+     */
+    private static Message createConnectMessage(boolean cleanSession, String clientId, byte protocolVersion,
+                                                byte expected) {
+        ConnectMessage connectMessage = new ConnectMessage();
+        connectMessage.setCleanSession(cleanSession);
+        connectMessage.setClientID(clientId);
+        connectMessage.setProcotolVersion(protocolVersion);
+        //Finally we create the message which the expected outcome
+        Message connection = new Message(connectMessage, expected);
+        return connection;
+    }
+}
+
+

--- a/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/commands/Message.java
+++ b/carbon-mb/components/transports/mqtt/src/test/java/org/wso2/carbon/transport/tests/mqtt/broker/v311/dataprovider/commands/Message.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.transport.tests.mqtt.broker.v311.dataprovider.commands;
+
+import org.wso2.carbon.andes.transports.mqtt.netty.protocol.messages.AbstractMessage;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Message data which will delegated from data provider to test case
+ */
+public class Message {
+    /**
+     * Specifies  the connect message the test should be executed against
+     */
+    private AbstractMessage message;
+
+    /**
+     * Properties which will be specific to the message
+     */
+    private Map<String, String> properties = new HashMap<>();
+
+    /**
+     * Specifies the expected result of the message
+     */
+    private Object expectedResult;
+
+    public Message() {
+        super();
+    }
+
+    public Message(AbstractMessage commandMessage, Object expectedResult) {
+        this.message = commandMessage;
+        this.expectedResult = expectedResult;
+    }
+
+    /**
+     * Adds a property which would represent in the message
+     *
+     * @param propertyName  the name of the property
+     * @param propertyValue the value of the property
+     */
+    public void addMessageProperty(String propertyName, String propertyValue) {
+        this.properties.put(propertyName, propertyValue);
+    }
+
+    /**
+     * Gets a property value by its name
+     *
+     * @param propertyName the name of the property to be retrieved
+     * @return the value of the property
+     */
+    public String getMessageProperty(String propertyName) {
+        return this.properties.get(propertyName);
+    }
+
+    /**
+     * Clears all properties in the message
+     */
+    public void clearProperties() {
+        this.properties.clear();
+    }
+
+    public AbstractMessage getMessage() {
+        return message;
+    }
+
+    public Object getExpectedResult() {
+        return expectedResult;
+    }
+}

--- a/carbon-mb/components/transports/mqtt/src/test/resources/testng.xml
+++ b/carbon-mb/components/transports/mqtt/src/test/resources/testng.xml
@@ -1,0 +1,9 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Broker 3.1.1v Test Suite" verbose="1" >
+    <test name="MqttCommandMessageTest" >
+        <classes>
+            <class name="org.wso2.carbon.transport.tests.mqtt.broker.v311.MqttBrokerTest" />
+        </classes>
+    </test>
+</suite>

--- a/product/carbon-home/conf/transports/mqtt-transports.yaml
+++ b/product/carbon-home/conf/transports/mqtt-transports.yaml
@@ -21,6 +21,14 @@ mqttTransportProperties:
  acceptanceThreads: 0
  workerThreads: 0
  id: mqtt
+
+mqttWebsocketTransportProperties:
+  host: localhost
+  port: 9773
+  acceptanceThreads: 0
+  workerThreads: 0
+  id: mqttWebSocket
+
 mqttSecuredTransportProperties:
 
  host: localhost


### PR DESCRIPTION
This would allow communicating MQTT messages via websockets. The transport could further be verified for its interoperability through the online websocket client [1]

[1] http://www.hivemq.com/demos/websocket-client/