### PR TITLE
Fix incorrect assert in cluster tests

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/AndesClient.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/AndesClient.java
@@ -27,12 +27,12 @@ import org.wso2.mb.integration.common.clients.exceptions.AndesClientException;
 import org.wso2.mb.integration.common.clients.operations.utils.AndesClientOutputParser;
 import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 
-import javax.jms.JMSException;
-import javax.naming.NamingException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.jms.JMSException;
+import javax.naming.NamingException;
 
 /**
  * This class represents the Andes Client which is used to publish/consume JMS messages. The JMS
@@ -165,7 +165,7 @@ public class AndesClient {
     public long getReceivedMessageCount() {
         long allReceivedMessageCount = 0L;
         for (AndesJMSConsumer consumer : consumers) {
-            allReceivedMessageCount = allReceivedMessageCount + consumer.getReceivedMessageCount().get();
+            allReceivedMessageCount = allReceivedMessageCount + consumer.getReceivedMessageCount();
         }
         return allReceivedMessageCount;
     }

--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/AndesJMSConsumer.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/AndesJMSConsumer.java
@@ -25,6 +25,8 @@ import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 import org.wso2.mb.integration.common.clients.operations.utils.ExchangeType;
 import org.wso2.mb.integration.common.clients.operations.utils.JMSDeliveryStatus;
 
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 import javax.jms.Connection;
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -43,8 +45,6 @@ import javax.jms.TopicConnectionFactory;
 import javax.jms.TopicSession;
 import javax.jms.TopicSubscriber;
 import javax.naming.NamingException;
-import java.io.IOException;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * The JMS message consumer used for creating a consumer, reading messages synchronously and also
@@ -539,8 +539,8 @@ public class AndesJMSConsumer extends AndesJMSBase
      *
      * @return The received message count.
      */
-    public AtomicLong getReceivedMessageCount() {
-        return this.receivedMessageCount;
+    public long getReceivedMessageCount() {
+        return this.receivedMessageCount.get();
     }
 
     /**

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java
@@ -37,37 +37,37 @@ import org.wso2.mb.integration.common.clients.operations.utils.ExchangeType;
 import org.wso2.mb.platform.common.utils.MBPlatformBaseTest;
 import org.xml.sax.SAXException;
 
-import javax.jms.JMSException;
-import javax.naming.NamingException;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import javax.jms.JMSException;
+import javax.naming.NamingException;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.xpath.XPathExpressionException;
 
 /**
  * Perform tests with all possible AMQP types and large number of messages.
  */
 public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
 
-    final long printPerMessageCount = 1000;
+    private final long printPerMessageCount = 1000;
 
-    String queueName1 = "mixedQueue1";
-    String queueName2 = "mixedQueue2";
+    private String queueName1 = "mixedQueue1";
+    private String queueName2 = "mixedQueue2";
 
-    String topicName1 = "mixedTopic1";
-    String topicName2 = "mixedTopic2";
+    private String topicName1 = "mixedTopic1";
+    private String topicName2 = "mixedTopic2";
 
-    HostAndPort broker1;
-    HostAndPort broker2;
+    private HostAndPort broker1;
+    private HostAndPort broker2;
 
-    Map<String, Set<AndesClient>> publishers = new HashMap<>();
-    Map<String, Set<AndesClient>> subscribers = new HashMap<>();
+    private Map<String, Set<AndesClient>> publishers = new HashMap<>();
+    private Map<String, Set<AndesClient>> subscribers = new HashMap<>();
 
-    Map<String, Long> sendCounts = new HashMap<>();
+    private Map<String, Long> sendCounts = new HashMap<>();
 
 
     /**


### PR DESCRIPTION
AtomicLong value returned by AndesJMSConsumer is checked against a long value leading to a
Object assert.

Fixed by returning a long value instead of AtomicLong