### PR TITLE
Fix incorrect assert in cluster tests

### DIFF
--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java
@@ -597,7 +597,7 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
             AndesClientUtils.waitForMessagesAndShutdown(subscriber, AndesClientConstants.DEFAULT_RUN_TIME);
 
             for (AndesJMSConsumer consumer : subscriber.getConsumers()) {
-                Assert.assertEquals(consumer.getReceivedMessageCount(), topic1SendCount, "Did not receive expected "
+                Assert.assertEquals(consumer.getReceivedMessageCount().get(), topic1SendCount, "Did not receive expected "
                         + "count for topic " + topicName1 + " for subscriber "
                         + consumer.getConfig().getSubscriptionID());
             }
@@ -610,7 +610,7 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
             AndesClientUtils.waitForMessagesAndShutdown(subscriber, AndesClientConstants.DEFAULT_RUN_TIME);
 
             for (AndesJMSConsumer consumer : subscriber.getConsumers()) {
-                Assert.assertEquals(consumer.getReceivedMessageCount(), topic2SendCount, "Did not receive expected "
+                Assert.assertEquals(consumer.getReceivedMessageCount().get(), topic2SendCount, "Did not receive expected "
                         + "count for topic " + topicName2 + " for subscriber "
                         + consumer.getConfig().getSubscriptionID());
             }


### PR DESCRIPTION
AtomicLong value returned by AndesJMSConsumer is checked against a long value leading to a
Object assert.

Fixed by returning a long value instead of AtomicLong