### PR TITLE
Added thread sleep for cluster tests

### DIFF
--- a/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/utils/AndesClientConstants.java
+++ b/modules/integration/tests-common/admin-clients/src/main/java/org/wso2/mb/integration/common/clients/operations/utils/AndesClientConstants.java
@@ -75,7 +75,9 @@ public class AndesClientConstants {
     public static final long DEFAULT_RUN_TIME = 10000L;
 
     /**
-     * Default waiting time that is used to check whether the consumer has received messages.
+     * Default waiting time that is used to check whether the consumer has received messages. Should be used when
+     * messages are being published to a different node from the on e from which messages are being consumed since it
+     * could take this much time for the subscription notification to get synced throughout the cluster.
      */
     public static final long DEFAULT_CLUSTER_SYNC_TIME = 1000;
 

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/LZ4CompressCompatibilityTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/LZ4CompressCompatibilityTestCase.java
@@ -142,6 +142,8 @@ public class LZ4CompressCompatibilityTestCase extends MBPlatformBaseTest {
         AndesClient consumerClient = new AndesClient(consumerConfig, true);
         consumerClient.startClient();
 
+        AndesClientUtils.sleepForInterval(AndesClientConstants.DEFAULT_CLUSTER_SYNC_TIME);
+
         AndesClient publisherClient = new AndesClient(publisherConfig, true);
         publisherClient.startClient();
 

--- a/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/mqtt/LZ4CompressCompatibilityMQTTClusterTestCase.java
+++ b/modules/integration/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/mqtt/LZ4CompressCompatibilityMQTTClusterTestCase.java
@@ -29,6 +29,8 @@ import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
 import org.wso2.mb.integration.common.clients.*;
+import org.wso2.mb.integration.common.clients.operations.utils.AndesClientConstants;
+import org.wso2.mb.integration.common.clients.operations.utils.AndesClientUtils;
 import org.wso2.mb.platform.tests.clustering.mqtt.DataProvider.QualityOfServiceDataProvider;
 import org.xml.sax.SAXException;
 
@@ -106,6 +108,8 @@ public class LZ4CompressCompatibilityMQTTClusterTestCase extends MQTTPlatformBas
         mqttClientEngine.createSubscriberConnection(topic, qualityOfService, noOfSubscribers, true,
                 ClientMode.BLOCKING, clientConnectionConfigurationForNode2);
 
+        AndesClientUtils.sleepForInterval(AndesClientConstants.DEFAULT_CLUSTER_SYNC_TIME);
+
         // Create the publisher
         mqttClientEngine.createPublisherConnection(topic, qualityOfService, payload, noOfPublishers, noOfMessages,
                 ClientMode.BLOCKING, clientConnectionConfigurationForNode3);
@@ -127,6 +131,8 @@ public class LZ4CompressCompatibilityMQTTClusterTestCase extends MQTTPlatformBas
         // Create the subscriber
         mqttClientEngine2.createSubscriberConnection(topic, qualityOfService, noOfSubscribers, true,
                 ClientMode.BLOCKING, clientConnectionConfigurationForNode5);
+
+        AndesClientUtils.sleepForInterval(AndesClientConstants.DEFAULT_CLUSTER_SYNC_TIME);
 
         // Create the publisher
         mqttClientEngine2.createPublisherConnection(topic, qualityOfService, payload, noOfPublishers, noOfMessages,


### PR DESCRIPTION
Added a thread sleep for cluster tests which use different nodes for message publishing and subscribing so that cluster events are synced in RDBMS mode. Same was done prviously for other test cases in https://github.com/wso2/product-mb/pull/419