### PR TITLE
subscription search by ID could not assert in the test case

### DIFF
--- a/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/subscriptions/SubscriptionSearchTestCase.java
+++ b/modules/integration/tests-ui-integration/src/test/java/org/wso2/carbon/mb/ui/test/subscriptions/SubscriptionSearchTestCase.java
@@ -247,10 +247,6 @@ public class SubscriptionSearchTestCase extends MBIntegrationUiBaseTest {
         result = topicSubscriptionsPage.getDurableActiveSubscriptionsCount();
         Assert.assertEquals(result, 1);
 
-        topicSubscriptionsPage.searchTopicSubscriptions("", "carbon:subSearchDurable", 0, false, false);
-        result = topicSubscriptionsPage.getDurableActiveSubscriptionsCount();
-        Assert.assertEquals(result, 3);
-
         //Stop the clients
         consumerClient1.stopClient();
         consumerClient2.stopClient();


### PR DESCRIPTION
The reason was the fix of #422, we have removed appending subscriber queue name into the identifier in the subscription page.