### PR TITLE
Removed serializers for Hazelcast based slot implementation

### DIFF
--- a/modules/distribution/src/main/conf/axis2.xml
+++ b/modules/distribution/src/main/conf/axis2.xml
@@ -690,15 +690,6 @@
         </parameter>
 
         <!--
-        Following parameters will load custom Hazelcast data serializers.
-        -->
-        <parameter name="hazelcastSerializers">
-            <serializer typeClass="org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.wrapper.TreeSetLongWrapper">org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.TreeSetLongWrapperSerializer</serializer>
-            <serializer typeClass="org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.wrapper.TreeSetSlotWrapper">org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.TreeSetSlotWrapperSerializer</serializer>
-            <serializer typeClass="org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.wrapper.HashmapStringTreeSetWrapper">org.wso2.andes.server.cluster.coordination.hazelcast.custom.serializer.HashMapStringTreeSetWrapperSerializer</serializer>
-        </parameter>
-
-        <!--
            The list of static or well-known members. These entries will only be valid if the
            "membershipScheme" above is set to "wka"
         -->


### PR DESCRIPTION
Removed serializers used in hazelcast slot agent. 

Related to https://github.com/wso2/andes/pull/852 and https://github.com/wso2/carbon-business-messaging/pull/426

The issue is tracked in at https://wso2.org/jira/browse/MB-1915