### PR TITLE
Renamed tests for message expiration

### DIFF
--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicMessageExpiryTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/DurableTopicMessageExpiryTestCase.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 /**
  * Unit tests to ensure jms expiration works as expected with durable topics.
  */
-public class MixedDurableTopicTestCase extends MBIntegrationBaseTest {
+public class DurableTopicMessageExpiryTestCase extends MBIntegrationBaseTest {
 
     /**
      * Total message amount published

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageExpireTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/QueueMessageExpireTestCase.java
@@ -40,7 +40,7 @@ import java.io.IOException;
 /**
  * This class includes unit tests to verify that messages with JMS expiration are properly removed when delivering to queues.
  */
-public class MixedQueueTestCase extends MBIntegrationBaseTest {
+public class QueueMessageExpireTestCase extends MBIntegrationBaseTest {
 
     /**
      * Initializing test case
@@ -185,8 +185,11 @@ public class MixedQueueTestCase extends MBIntegrationBaseTest {
         Assert.assertEquals(publisherClientWithoutExpiration.getSentMessageCount(), sendCountWithoutExpiration, "Message send failed for publisher without expiration.");
         Assert.assertEquals(publisherClientWithExpiration.getSentMessageCount(), sendCountWithExpiration, "Message send failed for publisher with expiration");
 
-        Assert.assertEquals(initialConsumerClient.getReceivedMessageCount(), expectedCountByOneSubscriber, "Message receiving failed for client 1.");
-        Assert.assertEquals(secondaryConsumerClient.getReceivedMessageCount(), expectedCountByOneSubscriber, "Message receiving failed for client 2.");
-        Assert.assertEquals(initialConsumerClient.getReceivedMessageCount() + secondaryConsumerClient.getReceivedMessageCount(), sendCountWithoutExpiration, "Message receiving failed.");
+        long consumer1MsgCount = initialConsumerClient.getReceivedMessageCount();
+        long consumer2MsgCount = secondaryConsumerClient.getReceivedMessageCount();
+
+        Assert.assertEquals((consumer1MsgCount + consumer2MsgCount) , sendCountWithoutExpiration,
+                "Message receiving failed. Expected " + sendCountWithoutExpiration + " but received "
+                        + (consumer1MsgCount + consumer2MsgCount));
     }
 }

--- a/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicMessageExpiryTestCase.java
+++ b/modules/integration/tests-integration/tests-amqp/src/test/java/org/wso2/mb/integration/tests/amqp/functional/TopicMessageExpiryTestCase.java
@@ -41,7 +41,7 @@ import java.io.IOException;
  * This class includes unit tests to verify that messages with JMS expiration are properly removed when delivering to
  * non-durable topics.
  */
-public class MixedTopicTestCase extends MBIntegrationBaseTest {
+public class TopicMessageExpiryTestCase extends MBIntegrationBaseTest {
 
     /**
      * Total message count sent

--- a/modules/integration/tests-integration/tests-amqp/src/test/resources/testng.xml
+++ b/modules/integration/tests-integration/tests-amqp/src/test/resources/testng.xml
@@ -64,7 +64,7 @@
             <class name="org.wso2.mb.integration.tests.amqp.functional.AutoAcknowledgementsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.ClientAcknowledgementsTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DuplicatesOkAcknowledgementsTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.MixedQueueTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.QueueMessageExpireTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultipleQueueSendReceiveTestCase"/>
             <!-- performMultipleQueueSendReceiveTestCase has been disabled in above test class until the issue is resolved.
             Its an intermittent failure. -->
@@ -85,8 +85,8 @@
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableMultipleTopicSubscriberTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicSubscriptionTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.MixedDurableTopicTestCase"/>
-            <class name="org.wso2.mb.integration.tests.amqp.functional.MixedTopicTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.DurableTopicMessageExpiryTestCase"/>
+            <class name="org.wso2.mb.integration.tests.amqp.functional.TopicMessageExpiryTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultipleTopicPublishSubscribeTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultiTenantDurableTopicTestCase"/>
             <class name="org.wso2.mb.integration.tests.amqp.functional.MultiTenantTopicTestCase"/>


### PR DESCRIPTION
 Fixed QueueMessageExpireTestCase to assert only the summation of number of messages received by two queue consumers. 